### PR TITLE
Stage 3b: translate getting-started/** to Russian (11 files)

### DIFF
--- a/docs/content/docs/1.getting-started/.navigation.yml
+++ b/docs/content/docs/1.getting-started/.navigation.yml
@@ -1,1 +1,1 @@
-title: Get Started
+title: Начало работы

--- a/docs/content/docs/1.getting-started/1.index.md
+++ b/docs/content/docs/1.getting-started/1.index.md
@@ -1,33 +1,33 @@
 ---
-title: Get Started
-description: 'Quick start guide for working with the SDK for Bitrix24 REST API'
+title: Начало работы
+description: 'Краткое руководство по работе с SDK для REST API Bitrix24'
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Эта страница ещё обновляется. Некоторые данные могут отсутствовать — мы их вскоре дополним.
 ::
 
-## Overview {#overview}
+## Обзор {#overview}
 
-The SDK for working with Bitrix24 REST API provides a unified interface for interacting with the Bitrix24 API from JavaScript/TypeScript applications. This page will help you quickly get started with the library.
+SDK для работы с REST API Bitrix24 предоставляет единый интерфейс для взаимодействия с API Bitrix24 из JavaScript/TypeScript-приложений. Эта страница поможет вам быстро начать работу с библиотекой.
 
-## Choosing the Appropriate Class {#choosing-the-appropriate-class}
+## Выбор подходящего класса {#choosing-the-appropriate-class}
 
-Choose a class depending on your usage scenario:
+Выберите класс в зависимости от сценария использования:
 
-| Scenario | Class | Description |
+| Сценарий | Класс | Описание |
 |----------|-------|----------|
-| Application embedded in the Bitrix24 interface | `B24Frame` | Automatically available in an iframe, uses the current user's token |
-| Standalone server application with webhook | `B24Hook` | Uses a permanent webhook token for server applications |
-| Standalone server application with OAuth | `B24OAuth` | Uses OAuth 2.0 with token refresh capability |
+| Приложение, встроенное в интерфейс Bitrix24 | `B24Frame` | Автоматически доступен в iframe, использует токен текущего пользователя |
+| Автономное серверное приложение с вебхуком | `B24Hook` | Использует постоянный токен вебхука для серверных приложений |
+| Автономное серверное приложение с OAuth | `B24OAuth` | Использует OAuth 2.0 с возможностью обновления токена |
 
-### For Client Applications (B24Frame) {#for-client-applications-b24frame}
+### Для клиентских приложений (B24Frame) {#for-client-applications-b24frame}
 
-If you are developing an application that will run inside the Bitrix24 interface:
+Если вы разрабатываете приложение, которое будет работать внутри интерфейса Bitrix24:
 
 // @check-ignore: declares own $b24 with B24Frame type without import
 ```ts
-// In an application embedded in Bitrix24
+// В приложении, встроенном в Bitrix24
 
 let $b24: undefined | B24Frame
 
@@ -53,7 +53,7 @@ async function getCurrentUser() {
   }
 }
 
-// Example of getting a list of contacts
+// Пример получения списка контактов
 async function getContacts() {
   if (!$b24) {
     return
@@ -81,23 +81,23 @@ async function init() {
 await init()
 ```
 
-### For Server Applications with Webhook (B24Hook) {#for-server-applications-with-webhook-b24hook}
+### Для серверных приложений с вебхуком (B24Hook) {#for-server-applications-with-webhook-b24hook}
 
-For server applications with permanent access via webhook:
+Для серверных приложений с постоянным доступом через вебхук:
 
 ```ts
 import { B24Hook } from '@bitrix24/b24jssdk'
 
-// 1. Get the webhook URL from Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Webhooks
-//    - Create a new webhook with the required permissions
-//    - Copy the URL in the format: https://your-domain.bitrix24.com/rest/1/your-token/
+// 1. Получите URL вебхука в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Вебхуки
+//    - Создайте новый вебхук с необходимыми правами
+//    - Скопируйте URL в формате: https://your-domain.bitrix24.com/rest/1/your-token/
 
-// 2. Initialize B24Hook
+// 2. Инициализируйте B24Hook
 const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
 
-// 3. Use API methods
+// 3. Используйте методы API
 async function getCompany(companyId: number) {
   const response = await $b24.actions.v2.call.make({
     method: 'crm.company.get',
@@ -112,7 +112,7 @@ async function getCompany(companyId: number) {
   }
 }
 
-// Example of bulk creating deals
+// Пример массового создания сделок
 async function createMultipleDeals(dealsData: Array<{title: string, opportunity: number}>) {
   const calls = dealsData.map((deal, index): [string, Record<string, unknown>] => [
     'crm.deal.add',
@@ -136,21 +136,21 @@ async function createMultipleDeals(dealsData: Array<{title: string, opportunity:
 }
 ```
 
-### For Server Applications with OAuth (B24OAuth) {#for-server-applications-with-oauth-b24oauth}
+### Для серверных приложений с OAuth (B24OAuth) {#for-server-applications-with-oauth-b24oauth}
 
-For server applications with OAuth 2.0 authentication:
+Для серверных приложений с аутентификацией через OAuth 2.0:
 
 ```ts
 import { B24OAuth } from '@bitrix24/b24jssdk'
 
-// 1. Register an application in Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Applications
-//    - Create a new application
-//    - Get the Client ID and Client Secret
+// 1. Зарегистрируйте приложение в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Приложения
+//    - Создайте новое приложение
+//    - Получите Client ID и Client Secret
 
-// 2. Initialize B24OAuth — pass token data and OAuth credentials separately.
-//    See the full B24OAuthParams shape on the OAuth reference page.
+// 2. Инициализируйте B24OAuth — передайте данные токена и OAuth-учётные данные отдельно.
+//    Полную форму B24OAuthParams см. на странице справочника OAuth.
 import { EnumAppStatus } from '@bitrix24/b24jssdk'
 
 const $b24 = new B24OAuth(
@@ -160,7 +160,7 @@ const $b24 = new B24OAuth(
     memberId: 'portal_member_id',
     accessToken: 'current_access_token',
     refreshToken: 'refresh_token',
-    expires: 1745997853, // unix timestamp, seconds
+    expires: 1745997853, // unix timestamp, секунды
     expiresIn: 3600,
     scope: 'crm,user_brief',
     domain: 'your-domain.bitrix24.com',
@@ -174,7 +174,7 @@ const $b24 = new B24OAuth(
   }
 )
 
-// 3. Use API methods
+// 3. Используйте методы API
 async function getTasks() {
   const response = await $b24.actions.v2.call.make({
     method: 'tasks.task.list',
@@ -188,21 +188,21 @@ async function getTasks() {
   return response
 }
 
-// B24OAuth automatically refreshes tokens when they expire
+// B24OAuth автоматически обновляет токены при их истечении
 ```
 
-## First Steps with API {#first-steps-with-api}
+## Первые шаги с API {#first-steps-with-api}
 
-### Simple Connection Test {#simple-connection-test}
+### Простой тест подключения {#simple-connection-test}
 
 // @check-ignore: partial snippet — B24Hook used without import
 ```typescript
-// Test API availability
+// Проверка доступности API
 async function testConnection() {
-  // For B24Hook or B24OAuth
+  // Для B24Hook или B24OAuth
   const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
   
-  // 1. Check availability
+  // 1. Проверьте доступность
   const isHealthy = await $b24.tools.healthCheck.make({
     requestId: 'health-check'
   })
@@ -212,14 +212,14 @@ async function testConnection() {
     return
   }
   
-  // 2. Measure speed
+  // 2. Измерьте скорость
   const pingTime = await $b24.tools.ping.make({
     requestId: 'ping-test'
   })
   
   console.log(`API available, response time: ${pingTime}ms`)
   
-  // 3. Get current user information
+  // 3. Получите данные текущего пользователя
   const userResponse = await $b24.actions.v2.call.make({
     method: 'user.current',
     requestId: 'get-current-user'
@@ -233,10 +233,10 @@ async function testConnection() {
 }
 ```
 
-### Basic CRM Operations {#basic-crm-operations}
+### Базовые операции с CRM {#basic-crm-operations}
 
 ```ts
-// Create a contact
+// Создание контакта
 async function createContact(name: string, lastName: string, email: string) {
   const response = await $b24.actions.v2.call.make({
     method: 'crm.contact.add',
@@ -253,7 +253,7 @@ async function createContact(name: string, lastName: string, email: string) {
   return response
 }
 
-// Get a list of contacts
+// Получение списка контактов
 async function getAllContacts() {
   const generator = $b24.actions.v2.fetchList.make({
     method: 'crm.contact.list',
@@ -275,18 +275,18 @@ async function getAllContacts() {
 }
 ```
 
-### Examples of Using Main Methods {#examples-of-using-main-methods}
+### Примеры использования основных методов {#examples-of-using-main-methods}
 
 // @check-ignore: partial snippet — processChunk not declared and top-level return
 ```ts
-// 1. Single call (Call)
+// 1. Одиночный вызов (Call)
 const singleItem = await $b24.actions.v2.call.make({
   method: 'crm.company.get',
   params: { id: 123 },
   requestId: 'single-call'
 })
 
-// 2. Get entire list (CallList)
+// 2. Получение всего списка (CallList)
 const allItems = await $b24.actions.v2.callList.make({
   method: 'crm.company.list',
   params: {
@@ -297,7 +297,7 @@ const allItems = await $b24.actions.v2.callList.make({
   requestId: 'get-all-companies'
 })
 
-// 3. Stream processing (FetchList)
+// 3. Потоковая обработка (FetchList)
 const generator = $b24.actions.v2.fetchList.make({
   method: 'crm.deal.list',
   params: { select: ['ID', 'TITLE', 'OPPORTUNITY'] },
@@ -306,11 +306,11 @@ const generator = $b24.actions.v2.fetchList.make({
 })
 
 for await (const chunk of generator) {
-  // Process in batches of 50 elements
+  // Обрабатываем пачками по 50 элементов
   processChunk(chunk)
 }
 
-// 4. Batch processing (Batch)
+// 4. Пакетная обработка (Batch)
 const batchResult = await $b24.actions.v2.batch.make({
   calls: [
     ['crm.company.get', { id: 1 }],
@@ -322,7 +322,7 @@ const batchResult = await $b24.actions.v2.batch.make({
   }
 })
 
-// 5. Bulk batch processing (BatchByChunk)
+// 5. Массовая пакетная обработка (BatchByChunk)
 const commands = Array.from({ length: 150 }, (_, i): [string, Record<string, unknown>] => [
   'crm.contact.add',
   { fields: { NAME: `Contact ${i + 1}` } }
@@ -336,26 +336,26 @@ const bulkResult = await $b24.actions.v2.batchByChunk.make({
 })
 ```
 
-## Tips for Beginners {#tips-for-beginners}
+## Советы для начинающих {#tips-for-beginners}
 
-### 1. Always Use requestId {#1-always-use-requestid}
+### 1. Всегда используйте requestId {#1-always-use-requestid}
 
 ```ts
-// Good
+// Хорошо
 await $b24.actions.v2.call.make({
   method: 'crm.contact.get',
   params: { id: 123 },
   requestId: `contact-${123}-${Date.now()}`
 })
 
-// Bad (without requestId it will be difficult to debug)
+// Плохо (без requestId будет сложно отладить)
 await $b24.actions.v2.call.make({
   method: 'crm.contact.get',
   params: { id: 123 }
 })
 ```
 
-### 2. Check Operation Results {#2-check-operation-results}
+### 2. Проверяйте результаты операций {#2-check-operation-results}
 
 // @check-ignore: top-level return in error-handling illustration
 ```ts
@@ -365,31 +365,31 @@ const response = await $b24.actions.v2.call.make({
   requestId: 'my-request'
 })
 
-// Always check isSuccess
+// Всегда проверяйте isSuccess
 if (!response.isSuccess) {
   console.error('Error:', response.getErrorMessages())
-  // Error handling
+  // Обработка ошибки
   return
 }
 
-// Only after successful check, work with the data
+// Только после успешной проверки работаем с данными
 const data = response.getData()!
 ```
 
-### 3. Choose the Right Method for Working with Lists {#3-choose-the-right-method-for-working-with-lists}
+### 3. Выбирайте правильный метод для работы со списками {#3-choose-the-right-method-for-working-with-lists}
 
-| Data Volume | Method | Why |
+| Объём данных | Метод | Почему |
 |--------------|-------|--------|
-| < 1000 records | `CallList` | Easy to use, all data at once |
-| > 1000 records | `FetchList` | Memory efficient, stream processing |
-| Selective data | `Call` + `Batch` | Only needed records, control over requests |
+| < 1000 записей | `CallList` | Удобно использовать, все данные сразу |
+| > 1000 записей | `FetchList` | Эффективен по памяти, потоковая обработка |
+| Выборочные данные | `Call` + `Batch` | Только нужные записи, контроль над запросами |
 
-## Need Help? {#need-help}
+## Нужна помощь? {#need-help}
 
-- [Open an issue on GitHub](https://github.com/bitrix24/b24jssdk/issues)
-- [View existing questions](https://github.com/bitrix24/b24jssdk/issues?q=is%3Aissue)
-- [Official documentation](https://apidocs.bitrix24.ru/)
+- [Открыть issue в GitHub](https://github.com/bitrix24/b24jssdk/issues)
+- [Посмотреть существующие вопросы](https://github.com/bitrix24/b24jssdk/issues?q=is%3Aissue)
+- [Официальная документация](https://apidocs.bitrix24.ru/)
 
 ---
 
-**Tip**: Start with simple queries (e.g., `user.current`) to make sure the connection works correctly before moving on to complex operations with CRM or tasks.
+**Совет**: Начните с простых запросов (например, `user.current`), чтобы убедиться, что соединение работает корректно, прежде чем переходить к сложным операциям с CRM или задачами.

--- a/docs/content/docs/1.getting-started/2.installation/1.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.vue.md
@@ -1,18 +1,18 @@
 ---
-title: Vue Project
-description: 'Guide for installing Bitrix24 JS SDK in Vue applications.'
+title: Проект на Vue
+description: 'Руководство по установке Bitrix24 JS SDK в приложениях Vue.'
 navigation.title: Vue
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Эта страница ещё обновляется. Некоторые данные могут отсутствовать — мы их вскоре дополним.
 ::
 
-## Add to a Vue project {#add-to-a-vue-project}
+## Установка в проект Vue {#add-to-a-vue-project}
 
 ::steps{level="3"}
 
-### Install the Bitrix24 JS SDK package {#install-the-bitrix24-js-sdk-package}
+### Установка пакета Bitrix24 JS SDK {#install-the-bitrix24-js-sdk-package}
 
 ::code-group{sync="pm"}
 
@@ -34,23 +34,23 @@ bun add @bitrix24/b24jssdk
 
 ::
 
-### Import {#import}
+### Импорт {#import}
 
-Import the library into your project:
+Импортируйте библиотеку в проект:
 
 ```ts
 import { LoggerFactory } from '@bitrix24/b24jssdk'
 ```
 
-### Init {#init}
+### Инициализация {#init}
 
 :::tabs
 
 ::::tabs-item{label="B24Frame"}
 
-To work with Bitrix24 from the application built into the Bitrix24 interface use the `B24Frame` object.
+Для работы с Bitrix24 из приложения, встроенного в интерфейс Bitrix24, используйте объект `B24Frame`.
 
-It is initialized on the client side using `initializeB24Frame()`.
+Он инициализируется на стороне клиента через `initializeB24Frame()`.
 
 ```vue  [SomePage.vue]
 <script setup lang="ts">
@@ -85,52 +85,52 @@ onUnmounted(() => {
 
 ::::tabs-item{label="B24Hook"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24Hook` object is intended **exclusively for use on the server**.
-- A webhook contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24Hook` предназначен **исключительно для использования на сервере**.
+- Вебхук содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24Hook` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24Hook`.
 
 ```ts
 import { B24Hook } from '@bitrix24/b24jssdk'
 
-// 1. Get the webhook URL from Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Webhooks
-//    - Create a new webhook with the required permissions
-//    - Copy the URL in the format: https://your-domain.bitrix24.com/rest/1/your-token/
+// 1. Получите URL вебхука в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Вебхуки
+//    - Создайте новый вебхук с необходимыми правами
+//    - Скопируйте URL в формате: https://your-domain.bitrix24.com/rest/1/your-token/
 
-// 2. Initialize B24Hook
+// 2. Инициализируйте B24Hook
 const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
 
-// 3. Use API methods
+// 3. Используйте методы API
 ```
 
 ::::
 
 ::::tabs-item{label="B24OAuth"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24OAuth` object is intended **exclusively for use on the server**.
-- A b24OAuth contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24OAuth` предназначен **исключительно для использования на сервере**.
+- B24OAuth содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24OAuth` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24OAuth`.
 
 ```ts
 import { B24OAuth } from '@bitrix24/b24jssdk'
 
-// 1. Register an application in Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Applications
-//    - Create a new application
-//    - Get the Client ID and Client Secret
+// 1. Зарегистрируйте приложение в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Приложения
+//    - Создайте новое приложение
+//    - Получите Client ID и Client Secret
 
-// 2. Initialize B24OAuth — pass token data and OAuth credentials separately.
-//    See /docs/working-with-the-rest-api/oauth/ for the full B24OAuthParams shape.
+// 2. Инициализируйте B24OAuth — передайте данные токена и OAuth-учётные данные отдельно.
+//    Полную форму B24OAuthParams см. на /docs/working-with-the-rest-api/oauth/.
 import { EnumAppStatus } from '@bitrix24/b24jssdk'
 
 const $b24 = new B24OAuth(
@@ -140,7 +140,7 @@ const $b24 = new B24OAuth(
     memberId: 'portal_member_id',
     accessToken: 'current_access_token',
     refreshToken: 'refresh_token',
-    expires: 1745997853, // unix timestamp, seconds
+    expires: 1745997853, // unix timestamp, секунды
     expiresIn: 3600,
     scope: 'crm,user_brief',
     domain: 'your-domain.bitrix24.com',
@@ -154,9 +154,9 @@ const $b24 = new B24OAuth(
   }
 )
 
-// 3. Use API methods
+// 3. Используйте методы API
 
-// B24OAuth automatically refreshes tokens when they expire
+// B24OAuth автоматически обновляет токены при их истечении
 ```
 
 ::::

--- a/docs/content/docs/1.getting-started/2.installation/2.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.nuxt.md
@@ -1,24 +1,24 @@
 ---
-title: Nuxt Project
-description: 'Guide for installing Bitrix24 JS SDK in Nuxt applications.'
+title: Проект на Nuxt
+description: 'Руководство по установке Bitrix24 JS SDK в приложениях Nuxt.'
 navigation.title: Nuxt
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Эта страница ещё обновляется. Некоторые данные могут отсутствовать — мы их вскоре дополним.
 ::
 
-## Add to a Nuxt project {#add-to-a-nuxt-project}
+## Установка в проект Nuxt {#add-to-a-nuxt-project}
 
-To access the **Bitrix24 JS SDK** in a **Nuxt** project, use the `@bitrix24/b24jssdk-nuxt` module.
+Для доступа к **Bitrix24 JS SDK** в проекте **Nuxt** используйте модуль `@bitrix24/b24jssdk-nuxt`.
 
 ::note
-Requires **Nuxt 4**. Make sure to upgrade to Nuxt 4 you begin.
+Требуется **Nuxt 4**. Перед началом убедитесь, что обновились до Nuxt 4.
 ::
 
 ::steps{level="3"}
 
-### Install the Bitrix24 JS SDK package {#install-the-bitrix24-js-sdk-package}
+### Установка пакета Bitrix24 JS SDK {#install-the-bitrix24-js-sdk-package}
 
 ::code-group{sync="pm"}
 
@@ -40,7 +40,7 @@ bun add @bitrix24/b24jssdk-nuxt
 
 ::
 
-### Add the Bitrix24 JS SDK module in your `nuxt.config.ts`{lang="ts-type"} {#add-the-bitrix24-js-sdk-module-in-your-nuxtconfigts}
+### Добавьте модуль Bitrix24 JS SDK в ваш `nuxt.config.ts`{lang="ts-type"} {#add-the-bitrix24-js-sdk-module-in-your-nuxtconfigts}
 
 // @check-ignore: defineNuxtConfig is a Nuxt auto-import, not available in SDK typecheck context
 ```ts [nuxt.config.ts]
@@ -49,23 +49,23 @@ export default defineNuxtConfig({
 })
 ```
 
-### Import {#import}
+### Импорт {#import}
 
-Import the library into your project:
+Импортируйте библиотеку в проект:
 
 ```ts
 import { LoggerFactory } from '@bitrix24/b24jssdk'
 ```
 
-### Init {#init}
+### Инициализация {#init}
 
 :::tabs
 
 ::::tabs-item{label="B24Frame"}
 
-To work with Bitrix24 from the application built into the Bitrix24 interface use the `B24Frame` object.
+Для работы с Bitrix24 из приложения, встроенного в интерфейс Bitrix24, используйте объект `B24Frame`.
 
-It is initialized on the client side using `initializeB24Frame()`.
+Он инициализируется на стороне клиента через `initializeB24Frame()`.
 
 ```vue  [SomePage.vue]
 <script setup lang="ts">
@@ -100,52 +100,52 @@ onUnmounted(() => {
 
 ::::tabs-item{label="B24Hook"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24Hook` object is intended **exclusively for use on the server**.
-- A webhook contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24Hook` предназначен **исключительно для использования на сервере**.
+- Вебхук содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24Hook` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24Hook`.
 
 ```ts
 import { B24Hook } from '@bitrix24/b24jssdk'
 
-// 1. Get the webhook URL from Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Webhooks
-//    - Create a new webhook with the required permissions
-//    - Copy the URL in the format: https://your-domain.bitrix24.com/rest/1/your-token/
+// 1. Получите URL вебхука в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Вебхуки
+//    - Создайте новый вебхук с необходимыми правами
+//    - Скопируйте URL в формате: https://your-domain.bitrix24.com/rest/1/your-token/
 
-// 2. Initialize B24Hook
+// 2. Инициализируйте B24Hook
 const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
 
-// 3. Use API methods
+// 3. Используйте методы API
 ```
 
 ::::
 
 ::::tabs-item{label="B24OAuth"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24OAuth` object is intended **exclusively for use on the server**.
-- A b24OAuth contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24OAuth` предназначен **исключительно для использования на сервере**.
+- B24OAuth содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24OAuth` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24OAuth`.
 
 ```ts
 import { B24OAuth } from '@bitrix24/b24jssdk'
 
-// 1. Register an application in Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Applications
-//    - Create a new application
-//    - Get the Client ID and Client Secret
+// 1. Зарегистрируйте приложение в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Приложения
+//    - Создайте новое приложение
+//    - Получите Client ID и Client Secret
 
-// 2. Initialize B24OAuth — pass token data and OAuth credentials separately.
-//    See /docs/working-with-the-rest-api/oauth/ for the full B24OAuthParams shape.
+// 2. Инициализируйте B24OAuth — передайте данные токена и OAuth-учётные данные отдельно.
+//    Полную форму B24OAuthParams см. на /docs/working-with-the-rest-api/oauth/.
 import { EnumAppStatus } from '@bitrix24/b24jssdk'
 
 const $b24 = new B24OAuth(
@@ -155,7 +155,7 @@ const $b24 = new B24OAuth(
     memberId: 'portal_member_id',
     accessToken: 'current_access_token',
     refreshToken: 'refresh_token',
-    expires: 1745997853, // unix timestamp, seconds
+    expires: 1745997853, // unix timestamp, секунды
     expiresIn: 3600,
     scope: 'crm,user_brief',
     domain: 'your-domain.bitrix24.com',
@@ -169,9 +169,9 @@ const $b24 = new B24OAuth(
   }
 )
 
-// 3. Use API methods
+// 3. Используйте методы API
 
-// B24OAuth automatically refreshes tokens when they expire
+// B24OAuth автоматически обновляет токены при их истечении
 ```
 
 ::::

--- a/docs/content/docs/1.getting-started/2.installation/3.react.md
+++ b/docs/content/docs/1.getting-started/2.installation/3.react.md
@@ -1,18 +1,18 @@
 ---
-title: React Project
-description: 'Guide for installing Bitrix24 JS SDK in React applications.'
+title: Проект на React
+description: 'Руководство по установке Bitrix24 JS SDK в приложениях React.'
 navigation.title: React
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Эта страница ещё обновляется. Некоторые данные могут отсутствовать — мы их вскоре дополним.
 ::
 
-## Add to a React project {#add-to-a-react-project}
+## Установка в проект React {#add-to-a-react-project}
 
 ::steps{level="3"}
 
-### Install the Bitrix24 JS SDK package {#install-the-bitrix24-js-sdk-package}
+### Установка пакета Bitrix24 JS SDK {#install-the-bitrix24-js-sdk-package}
 
 ::code-group{sync="pm"}
 
@@ -34,23 +34,23 @@ bun add @bitrix24/b24jssdk
 
 ::
 
-### Import {#import}
+### Импорт {#import}
 
-Import the library into your project:
+Импортируйте библиотеку в проект:
 
 ```ts
 import { LoggerFactory } from '@bitrix24/b24jssdk'
 ```
 
-### Init {#init}
+### Инициализация {#init}
 
 :::tabs
 
 ::::tabs-item{label="B24Frame"}
 
-To work with Bitrix24 from the application built into the Bitrix24 interface use the `B24Frame` object.
+Для работы с Bitrix24 из приложения, встроенного в интерфейс Bitrix24, используйте объект `B24Frame`.
 
-It is initialized on the client side using `initializeB24Frame()`.
+Он инициализируется на стороне клиента через `initializeB24Frame()`.
 
 ```tsx  [App.tsx]
 import type { B24Frame, ISODate } from '@bitrix24/b24jssdk';
@@ -136,63 +136,63 @@ function App() {
 export default App;
 ```
 
-Key React-specific considerations:
+Ключевые особенности React:
 
-* **Use React Hooks:** Initialize B24Frame in useEffect with cleanup function
-* **Use Refs:** Store B24Frame instance in a ref to persist it between renders
-* **Cleanup:** Always call destroy() when component unmounts to prevent memory leaks
-* **Environment:** Remember that B24Frame only works within Bitrix24 iframe
+* **Используйте React-хуки:** инициализируйте B24Frame в useEffect с функцией очистки
+* **Используйте Refs:** храните экземпляр B24Frame в ref, чтобы он сохранялся между рендерами
+* **Очистка:** всегда вызывайте destroy() при размонтировании компонента, чтобы избежать утечек памяти
+* **Окружение:** помните, что B24Frame работает только внутри iframe Bitrix24
 
 ::::
 
 ::::tabs-item{label="B24Hook"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24Hook` object is intended **exclusively for use on the server**.
-- A webhook contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24Hook` предназначен **исключительно для использования на сервере**.
+- Вебхук содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24Hook` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24Hook`.
 
 ```ts
 import { B24Hook } from '@bitrix24/b24jssdk'
 
-// 1. Get the webhook URL from Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Webhooks
-//    - Create a new webhook with the required permissions
-//    - Copy the URL in the format: https://your-domain.bitrix24.com/rest/1/your-token/
+// 1. Получите URL вебхука в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Вебхуки
+//    - Создайте новый вебхук с необходимыми правами
+//    - Скопируйте URL в формате: https://your-domain.bitrix24.com/rest/1/your-token/
 
-// 2. Initialize B24Hook
+// 2. Инициализируйте B24Hook
 const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
 
-// 3. Use API methods
+// 3. Используйте методы API
 ```
 
 ::::
 
 ::::tabs-item{label="B24OAuth"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24OAuth` object is intended **exclusively for use on the server**.
-- A b24OAuth contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24OAuth` предназначен **исключительно для использования на сервере**.
+- B24OAuth содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24OAuth` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24OAuth`.
 
 ```ts
 import { B24OAuth } from '@bitrix24/b24jssdk'
 
-// 1. Register an application in Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Applications
-//    - Create a new application
-//    - Get the Client ID and Client Secret
+// 1. Зарегистрируйте приложение в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Приложения
+//    - Создайте новое приложение
+//    - Получите Client ID и Client Secret
 
-// 2. Initialize B24OAuth — pass token data and OAuth credentials separately.
-//    See /docs/working-with-the-rest-api/oauth/ for the full B24OAuthParams shape.
+// 2. Инициализируйте B24OAuth — передайте данные токена и OAuth-учётные данные отдельно.
+//    Полную форму B24OAuthParams см. на /docs/working-with-the-rest-api/oauth/.
 import { EnumAppStatus } from '@bitrix24/b24jssdk'
 
 const $b24 = new B24OAuth(
@@ -202,7 +202,7 @@ const $b24 = new B24OAuth(
     memberId: 'portal_member_id',
     accessToken: 'current_access_token',
     refreshToken: 'refresh_token',
-    expires: 1745997853, // unix timestamp, seconds
+    expires: 1745997853, // unix timestamp, секунды
     expiresIn: 3600,
     scope: 'crm,user_brief',
     domain: 'your-domain.bitrix24.com',
@@ -216,9 +216,9 @@ const $b24 = new B24OAuth(
   }
 )
 
-// 3. Use API methods
+// 3. Используйте методы API
 
-// B24OAuth automatically refreshes tokens when they expire
+// B24OAuth автоматически обновляет токены при их истечении
 ```
 
 ::::

--- a/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
+++ b/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
@@ -1,30 +1,30 @@
 ---
-title: Node.js Project
-description: 'Guide for installing Bitrix24 JS SDK in Node.js applications.'
+title: Проект на Node.js
+description: 'Руководство по установке Bitrix24 JS SDK в приложениях Node.js.'
 navigation.title: Node.js
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Эта страница ещё обновляется. Некоторые данные могут отсутствовать — мы их вскоре дополним.
 ::
 
-## Add to a Node.js project {#add-to-a-nodejs-project}
+## Установка в проект Node.js {#add-to-a-nodejs-project}
 
 ::note
-Since version `0.4.0` CommonJs is not supported. Only `ESM` and `UMD`.
+Начиная с версии `0.4.0` CommonJs не поддерживается. Только `ESM` и `UMD`.
 ::
 
-Before you begin, make sure you have the latest version of Node.js installed.
+Перед началом убедитесь, что у вас установлена последняя версия Node.js.
 
 ::note
-We support version Node.js `^18.0.0 || ^20.0.0 || >=22.0.0`
+Поддерживаются версии Node.js `^18.0.0 || ^20.0.0 || >=22.0.0`
 ::
 
-Then run the following command to install the library:
+Затем выполните следующую команду для установки библиотеки:
 
 ::steps{level="3"}
 
-### Install the Bitrix24 JS SDK package {#install-the-bitrix24-js-sdk-package}
+### Установка пакета Bitrix24 JS SDK {#install-the-bitrix24-js-sdk-package}
 
 ::code-group{sync="pm"}
 
@@ -46,66 +46,66 @@ bun add @bitrix24/b24jssdk
 
 ::
 
-### Import {#import}
+### Импорт {#import}
 
-Import the library into your project:
+Импортируйте библиотеку в проект:
 
 ```ts
 import { LoggerFactory } from '@bitrix24/b24jssdk'
 ```
 
-### Init {#init}
+### Инициализация {#init}
 
 :::tabs
 
 ::::tabs-item{label="B24Hook"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24Hook` object is intended **exclusively for use on the server**.
-- A webhook contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24Hook` предназначен **исключительно для использования на сервере**.
+- Вебхук содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24Hook` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24Hook`.
 
 ```ts
 import { B24Hook } from '@bitrix24/b24jssdk'
 
-// 1. Get the webhook URL from Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Webhooks
-//    - Create a new webhook with the required permissions
-//    - Copy the URL in the format: https://your-domain.bitrix24.com/rest/1/your-token/
+// 1. Получите URL вебхука в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Вебхуки
+//    - Создайте новый вебхук с необходимыми правами
+//    - Скопируйте URL в формате: https://your-domain.bitrix24.com/rest/1/your-token/
 
-// 2. Initialize B24Hook
+// 2. Инициализируйте B24Hook
 const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
 
-// 3. Use API methods
+// 3. Используйте методы API
 ```
 
 ::::
 
 ::::tabs-item{label="B24OAuth"}
 
-::caution{title="⚠️ SECURITY"}
-The `B24OAuth` object is intended **exclusively for use on the server**.
-- A b24OAuth contains a secret access key, which **MUST NOT** be used in client-side code (browser, mobile app).
-- For the client side, use [`B24Frame`]
+::caution{title="⚠️ БЕЗОПАСНОСТЬ"}
+Объект `B24OAuth` предназначен **исключительно для использования на сервере**.
+- B24OAuth содержит секретный ключ доступа, который **НЕЛЬЗЯ** использовать в клиентском коде (браузер, мобильное приложение).
+- Для клиентской стороны используйте [`B24Frame`]
 ::
 
-To work with Bitrix24 from a standalone server-side application, use the `B24OAuth` object.
+Для работы с Bitrix24 из автономного серверного приложения используйте объект `B24OAuth`.
 
 ```ts
 import { B24OAuth } from '@bitrix24/b24jssdk'
 
-// 1. Register an application in Bitrix24:
-//    - Go to Bitrix24
-//    - Settings → Developers → Applications
-//    - Create a new application
-//    - Get the Client ID and Client Secret
+// 1. Зарегистрируйте приложение в Bitrix24:
+//    - Перейдите в Bitrix24
+//    - Настройки → Разработчикам → Приложения
+//    - Создайте новое приложение
+//    - Получите Client ID и Client Secret
 
-// 2. Initialize B24OAuth — pass token data and OAuth credentials separately.
-//    See /docs/working-with-the-rest-api/oauth/ for the full B24OAuthParams shape.
+// 2. Инициализируйте B24OAuth — передайте данные токена и OAuth-учётные данные отдельно.
+//    Полную форму B24OAuthParams см. на /docs/working-with-the-rest-api/oauth/.
 import { EnumAppStatus } from '@bitrix24/b24jssdk'
 
 const $b24 = new B24OAuth(
@@ -115,7 +115,7 @@ const $b24 = new B24OAuth(
     memberId: 'portal_member_id',
     accessToken: 'current_access_token',
     refreshToken: 'refresh_token',
-    expires: 1745997853, // unix timestamp, seconds
+    expires: 1745997853, // unix timestamp, секунды
     expiresIn: 3600,
     scope: 'crm,user_brief',
     domain: 'your-domain.bitrix24.com',
@@ -129,9 +129,9 @@ const $b24 = new B24OAuth(
   }
 )
 
-// 3. Use API methods
+// 3. Используйте методы API
 
-// B24OAuth automatically refreshes tokens when they expire
+// B24OAuth автоматически обновляет токены при их истечении
 ```
 
 ::::

--- a/docs/content/docs/1.getting-started/2.installation/5.umd.md
+++ b/docs/content/docs/1.getting-started/2.installation/5.umd.md
@@ -1,54 +1,54 @@
 ---
 title: UMD
-description: 'Guide for using UMD version Bitrix24 JS SDK in you applications.'
+description: 'Руководство по использованию UMD-версии Bitrix24 JS SDK в ваших приложениях.'
 audited: 2026-05-05
 links:
-  - label: Build config (UMD output)
+  - label: Конфигурация сборки (UMD-вывод)
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/build.config.ts
 ---
 
-## Add to you project {#add-to-you-project}
+## Установка в проект {#add-to-you-project}
 
 ::steps{level="3"}
 
-### Include the library {#include-the-library}
+### Подключение библиотеки {#include-the-library}
 
-You can include the library directly via CDN. Add the following `<script>` tag to your HTML file:
+Вы можете подключить библиотеку напрямую через CDN. Добавьте следующий тег `<script>` в HTML-файл:
 
 ```html
 <script src="https://unpkg.com/@bitrix24/b24jssdk@latest/dist/umd/index.min.js"></script>
 ```
-If necessary, download the UMD version of the library from [unpkg.com](https://unpkg.com/browse/@bitrix24/b24jssdk@latest/dist/) and add it to your project.
+При необходимости скачайте UMD-версию библиотеки с [unpkg.com](https://unpkg.com/browse/@bitrix24/b24jssdk@latest/dist/) и добавьте её в проект.
 
-Then include it in your HTML file:
+Затем подключите её в HTML-файл:
 
 ```html
 <script src="/path/to/umd/index.min.js"></script>
 ```
-### Import {#import}
+### Импорт {#import}
 
-After including, the library will be available through the global variable `B24Js`.
+После подключения библиотека будет доступна через глобальную переменную `B24Js`.
 
 ```js
 B24Js.LoggerFactory.createForBrowser('B24/jsSdk::umd', true);
 ```
 
-### Init {#init}
+### Инициализация {#init}
 
 :::tabs
 
 ::::tabs-item{label="B24Frame"}
 
-To work with Bitrix24 from the application built into the Bitrix24 interface use the `B24Frame` object.
+Для работы с Bitrix24 из приложения, встроенного в интерфейс Bitrix24, используйте объект `B24Frame`.
 
-It is initialized on the client side using `initializeB24Frame()`.
+Он инициализируется на стороне клиента через `initializeB24Frame()`.
 
 ```js
 const logger = B24Js.LoggerFactory.createForBrowser('B24/jsSdk::umd', true);
 
 try {
-  // Initialize B24Frame instance
+  // Инициализация экземпляра B24Frame
   let b24 = await B24Js.initializeB24Frame();
   
 } catch (error) {
@@ -62,14 +62,14 @@ try {
 
 ::
 
-## Examples {#examples}
+## Примеры {#examples}
 
 ### B24Frame :badge{label="client-side" class="align-text-top"} {#b24frame-badge}
 
-Here's a simple example demonstrating how to get a list of companies.
+Простой пример получения списка компаний.
 
 ::note{color="air-secondary" icon-name="Bitrix24Icon" to="https://apidocs.bitrix24.ru/local-integrations/serverside-local-app-with-ui.html"}
-The code is expected to run in the Bitrix24 user interface.
+Код предполагается запускать в интерфейсе Bitrix24.
 ::
 
 ::rest-api-version-only
@@ -88,11 +88,11 @@ The code is expected to run in the Bitrix24 user interface.
 
 <script src="https://unpkg.com/@bitrix24/b24jssdk@latest/dist/umd/index.min.js"></script>
 <script>
-  // Create logger
+  // Создание логгера
   const logger = B24Js.LoggerFactory.createForBrowser('B24/jsSdk::umd', true);
 
   /**
-   * Load company list
+   * Загрузка списка компаний
    */
   async function loadCompanies(b24) {
     try {
@@ -126,24 +126,24 @@ The code is expected to run in the Bitrix24 user interface.
   }
 
   /**
-   * Main application function
+   * Главная функция приложения
    */
   async function main() {
     try {
-      // Initialize B24Frame instance
+      // Инициализация экземпляра B24Frame
       let b24 = await B24Js.initializeB24Frame();
 
-      // Load companies
+      // Загрузка компаний
       const companies = await loadCompanies(b24);
 
-      // Further data processing...
+      // Дальнейшая обработка данных…
       logger.info('Loaded ' + companies.length + ' companies');
     } catch (error) {
       logger.error('Some problems', { error })
     }
   }
 
-  /// Start application after DOM load
+  /// Запуск приложения после загрузки DOM
   document.addEventListener('DOMContentLoaded', function() {
     main();
   });
@@ -167,11 +167,11 @@ The code is expected to run in the Bitrix24 user interface.
 
 <script src="https://unpkg.com/@bitrix24/b24jssdk@latest/dist/umd/index.min.js"></script>
 <script>
-  // Create logger
+  // Создание логгера
   const logger = B24Js.LoggerFactory.createForBrowser('B24/jsSdk::umd', true);
 
   /**
-   * Load company list
+   * Загрузка списка компаний
    */
   async function loadCompanies(b24) {
     try {
@@ -205,24 +205,24 @@ The code is expected to run in the Bitrix24 user interface.
   }
 
   /**
-   * Main application function
+   * Главная функция приложения
    */
   async function main() {
     try {
-      // Initialize B24Frame instance
+      // Инициализация экземпляра B24Frame
       let b24 = await B24Js.initializeB24Frame();
 
-      // Load companies
+      // Загрузка компаний
       const companies = await loadCompanies(b24);
 
-      // Further data processing...
+      // Дальнейшая обработка данных…
       logger.info('Loaded ' + companies.length + ' companies');
     } catch (error) {
       logger.error('Some problems', { error })
     }
   }
 
-  /// Start application after DOM load
+  /// Запуск приложения после загрузки DOM
   document.addEventListener('DOMContentLoaded', function() {
     main();
   });

--- a/docs/content/docs/1.getting-started/3.migration/1.v1.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v1.md
@@ -1,27 +1,27 @@
 ---
-title: Migration to v1
-description: 'A comprehensive guide to migrate your application from Bitrix24 JS SDK v0 to Bitrix24 JS SDK v1.'
+title: Миграция на v1
+description: 'Подробное руководство по миграции приложения с Bitrix24 JS SDK v0 на Bitrix24 JS SDK v1.'
 audited: 2026-05-29
-navigation.title: v0 to v1
+navigation.title: v0 → v1
 links:
   - label: CHANGELOG
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/CHANGELOG.md
 ---
 
-This guide provides step-by-step instructions to migrate your application to Bitrix24 JS SDK v1.
+Это руководство содержит пошаговые инструкции по миграции приложения на Bitrix24 JS SDK v1.
 
 ::note
-We've tried to maintain compatibility, but if any issues arise, please [let us know](https://github.com/bitrix24/b24jssdk/issues).
+Мы старались сохранить совместимость, но если возникнут проблемы, [сообщите нам](https://github.com/bitrix24/b24jssdk/issues).
 ::
 
-After upgrading to Bitrix24 JS SDK v1, please note the following important changes:
+После обновления до Bitrix24 JS SDK v1 обратите внимание на следующие важные изменения:
 
-## Change {#change}
+## Изменения {#change}
 
 ### PlacementManager.title {#placementmanagertitle}
 
-To align with documentation and reduce confusion, the `PlacementManager.title` property has been renamed to `PlacementManager.placement`.
+Для согласованности с документацией и устранения путаницы свойство `PlacementManager.title` переименовано в `PlacementManager.placement`.
 
 ```diff
 - if (b24Frame.placement.title === 'DEFAULT') {
@@ -32,9 +32,9 @@ To align with documentation and reduce confusion, the `PlacementManager.title` p
 
 ### TypeB24.getTargetOriginWithPath {#typeb24gettargetoriginwithpath}
 
-> Get the account address Bitrix24 with path
+> Получает адрес аккаунта Bitrix24 с путём
 
-The function now returns paths for `restApi:v2` and `restApi:v3`.
+Функция теперь возвращает пути для `restApi:v2` и `restApi:v3`.
 
 ```diff
 + import { ApiVersion } from '@bitrix24/b24jssdk'
@@ -46,9 +46,9 @@ The function now returns paths for `restApi:v2` and `restApi:v3`.
 
 ### TypeB24.getHttpClient {#typeb24gethttpclient}
 
-> Returns the HTTP client to perform the request.
+> Возвращает HTTP-клиент для выполнения запроса.
 
-The function now returns HTTP client for `restApi:v2` and `restApi:v3`.
+Функция теперь возвращает HTTP-клиент для `restApi:v2` и `restApi:v3`.
 
 ```diff
 + import { ApiVersion } from '@bitrix24/b24jssdk'
@@ -60,7 +60,7 @@ The function now returns HTTP client for `restApi:v2` and `restApi:v3`.
 
 ### Error {#error}
 
-All errors now inherit from `SdkError`{lang="ts-type"}. Just be aware of that.
+Все ошибки теперь наследуются от `SdkError`{lang="ts-type"}. Учитывайте это.
 
 ```diff
 + import { SdkError } from '@bitrix24/b24jssdk'
@@ -75,26 +75,26 @@ try {
 }
 ```
 
-## Removed {#removed}
+## Удалено {#removed}
 
-### Unused methods in TypeHttp {#unused-methods-in-typehttp}
+### Неиспользуемые методы TypeHttp {#unused-methods-in-typehttp}
 
-Request registration methods:
+Методы регистрации запросов:
 
 * `TypeHttp.setLogTag()`{lang="ts-type"}
 * `TypeHttp.clearLogTag()`{lang="ts-type"}
 
-Now you need to use the `requestId` parameter for these purposes.
+Теперь для этих целей нужно использовать параметр `requestId`.
 
-### Unused methods in Http {#unused-methods-in-http}
+### Неиспользуемые методы Http {#unused-methods-in-http}
 
-Method for displaying system messages `Http.getSystemLogger()`{lang="ts-type"}
+Метод вывода системных сообщений `Http.getSystemLogger()`{lang="ts-type"}
 
-Now forced display is used via [`LoggerFactory.forcedLog()`{lang="ts-type"}](/docs/working-with-the-rest-api/logger/)
+Теперь используется принудительный вывод через [`LoggerFactory.forcedLog()`{lang="ts-type"}](/docs/working-with-the-rest-api/logger/)
 
 ### Restriction Manager {#restriction-manager}
 
-The `RestrictionManager` class has been removed. The [`Limiters`](/docs/working-with-the-rest-api/limiters/) system is used instead.
+Класс `RestrictionManager` удалён. Вместо него используется система [`Limiters`](/docs/working-with-the-rest-api/limiters/).
 
 ```diff
 - import { RestrictionManagerParamsForEnterprise } from '@bitrix24/b24jssdk'
@@ -109,13 +109,13 @@ The `RestrictionManager` class has been removed. The [`Limiters`](/docs/working-
 + $b24.setRestrictionManagerParams( { rateLimit: { burstLimit: 250, drainRate: 5 } } )
 ```
 
-## Deprecated {#deprecated}
+## Устарело {#deprecated}
 
 ### AbstractB24.batchSize {#abstractb24batchsize}
 
-> Maximum length for batch response.
+> Максимальная длина пакетного ответа.
 
-This const is deprecated and will be removed in version `2.0.0`.
+Эта константа устарела и будет удалена в версии `2.0.0`.
 
 ```diff
 - if (size < AbstractB24.batchSize) {
@@ -126,15 +126,15 @@ This const is deprecated and will be removed in version `2.0.0`.
 
 ### TypeB24.callMethod {#typeb24callmethod}
 
-> Calls the Bitrix24 REST API method.
+> Вызывает метод REST API Bitrix24.
 
-This method is deprecated and will be removed in version `2.0.0`.
+Этот метод устарел и будет удалён в версии `2.0.0`.
 
 ::tabs{class="mt-0"}
 
 :::tabs-item{label="restApi:v2"}
 
-For `restApi:v2`, you must use the [`b24.actions.v2.call.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-rest-api-ver2/) method.
+Для `restApi:v2` следует использовать метод [`b24.actions.v2.call.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-rest-api-ver2/).
 
 ```diff
 - await b24.callMethod('some.method', { filter: { '>id': 123 } }, 100)
@@ -152,7 +152,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.call.make(options)`{lang="ts
 
 :::tabs-item{label="restApi:v3"}
 
-For `restApi:v3`, you must use the [`b24.actions.v3.call.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-rest-api-ver3/) method.
+Для `restApi:v3` следует использовать метод [`b24.actions.v3.call.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-rest-api-ver3/).
 
 ```diff
 - await b24.callMethod('some.method', { filter: { '>id': 123 } }, 100)
@@ -172,15 +172,15 @@ For `restApi:v3`, you must use the [`b24.actions.v3.call.make(options)`{lang="ts
 
 ### TypeB24.callListMethod {#typeb24calllistmethod}
 
-> Calls a Bitrix24 REST API list method to retrieve all data.
+> Вызывает list-метод REST API Bitrix24 для получения всех данных.
 
-This method is deprecated and will be removed in version `2.0.0`.
+Этот метод устарел и будет удалён в версии `2.0.0`.
 
 ::tabs{class="mt-0"}
 
 :::tabs-item{label="restApi:v2"}
 
-For `restApi:v2`, you must use the [`b24.actions.v2.callList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver2/) method.
+Для `restApi:v2` следует использовать метод [`b24.actions.v2.callList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver2/).
 
 ```diff
 - await b24.callListMethod('some.method', { filter: { '>id': 123 } }, null, 'items')
@@ -197,7 +197,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.callList.make(options)`{lang
 
 :::tabs-item{label="restApi:v3"}
 
-For `restApi:v3`, you must use the [`b24.actions.v3.callList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver3/) method.
+Для `restApi:v3` следует использовать метод [`b24.actions.v3.callList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver3/).
 
 ```diff
 - await b24.callListMethod('some.method', { filter: { '>id': 123 } }, null, 'items')
@@ -217,15 +217,15 @@ For `restApi:v3`, you must use the [`b24.actions.v3.callList.make(options)`{lang
 
 ### TypeB24.fetchListMethod {#typeb24fetchlistmethod}
 
-> Calls a Bitrix24 REST API list method and returns an async generator.
+> Вызывает list-метод REST API Bitrix24 и возвращает асинхронный генератор.
 
-This method is deprecated and will be removed in version `2.0.0`.
+Этот метод устарел и будет удалён в версии `2.0.0`.
 
 ::tabs{class="mt-0"}
 
 :::tabs-item{label="restApi:v2"}
 
-For `restApi:v2`, you must use the [`b24.actions.v2.fetchList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/fetch-list-rest-api-ver2/) method.
+Для `restApi:v2` следует использовать метод [`b24.actions.v2.fetchList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/fetch-list-rest-api-ver2/).
 
 ```diff
 - b24.fetchListMethod('some.method', { filter: { '>id': 123 } }, 'id', 'items')
@@ -242,7 +242,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.fetchList.make(options)`{lan
 
 :::tabs-item{label="restApi:v3"}
 
-For `restApi:v3`, you must use the [`b24.actions.v3.fetchList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/fetch-list-rest-api-ver3/) method.
+Для `restApi:v3` следует использовать метод [`b24.actions.v3.fetchList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/fetch-list-rest-api-ver3/).
 
 ```diff
 - b24.fetchListMethod('some.method', { filter: { '>id': 123 } }, 'id', 'items')
@@ -262,15 +262,15 @@ For `restApi:v3`, you must use the [`b24.actions.v3.fetchList.make(options)`{lan
 
 ### TypeB24.callBatch {#typeb24callbatch}
 
-> Executes a batch request to the Bitrix24 REST API.
+> Выполняет пакетный запрос к REST API Bitrix24.
 
-This method is deprecated and will be removed in version `2.0.0`.
+Этот метод устарел и будет удалён в версии `2.0.0`.
 
 ::tabs{class="mt-0"}
 
 :::tabs-item{label="restApi:v2"}
 
-For `restApi:v2`, you must use the [`b24.actions.v2.batch.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-rest-api-ver2/) method.
+Для `restApi:v2` следует использовать метод [`b24.actions.v2.batch.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-rest-api-ver2/).
 
 ```diff
 - await b24.callBatch([['some.method.1', { filter: { '>id': 123 } }], ['some.method.2', { filter: { '<id': 456 } }]], true, true)
@@ -291,7 +291,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.batch.make(options)`{lang="t
 
 :::tabs-item{label="restApi:v3"}
 
-For `restApi:v3`, you must use the [`b24.actions.v3.batch.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-rest-api-ver3/) method.
+Для `restApi:v3` следует использовать метод [`b24.actions.v3.batch.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-rest-api-ver3/).
 
 ```diff
 - await b24.callBatch([['some.method.1', { filter: { '>id': 123 } }], ['some.method.2', { filter: { '<id': 456 } }]], true, true)
@@ -314,15 +314,15 @@ For `restApi:v3`, you must use the [`b24.actions.v3.batch.make(options)`{lang="t
 
 ### TypeB24.callBatchByChunk {#typeb24callbatchbychunk}
 
-> Executes a batch request to the Bitrix24 REST API with automatic chunking for any number of commands.
+> Выполняет пакетный запрос к REST API Bitrix24 с автоматическим разбиением на чанки для любого числа команд.
 
-This method is deprecated and will be removed in version `2.0.0`.
+Этот метод устарел и будет удалён в версии `2.0.0`.
 
 ::tabs{class="mt-0"}
 
 :::tabs-item{label="restApi:v2"}
 
-For `restApi:v2`, you must use the [`b24.actions.v2.batchByChunk.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/) method.
+Для `restApi:v2` следует использовать метод [`b24.actions.v2.batchByChunk.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/).
 
 ```diff
 - await b24.callBatchByChunk([['some.method.1', { filter: { '>id': 123 } }], ['some.method.2', { filter: { '<id': 456 } }]], true)
@@ -342,7 +342,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.batchByChunk.make(options)`{
 
 :::tabs-item{label="restApi:v3"}
 
-For `restApi:v3`, you must use the [`b24.actions.v3.batchByChunk.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver3/) method.
+Для `restApi:v3` следует использовать метод [`b24.actions.v3.batchByChunk.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver3/).
 
 ```diff
 - await b24.callBatchByChunk([['some.method.1', { filter: { '>id': 123 } }], ['some.method.2', { filter: { '<id': 456 } }]], true)
@@ -364,11 +364,11 @@ For `restApi:v3`, you must use the [`b24.actions.v3.batchByChunk.make(options)`{
 
 ### LoggerBrowser {#loggerbrowser}
 
-> Used for logging data
+> Используется для логирования данных
 
-This class is deprecated and will be removed in version `2.0.0`.
+Этот класс устарел и будет удалён в версии `2.0.0`.
 
-Now a more [universal logging system](/docs/working-with-the-rest-api/logger/) is used, somewhat similar to [`Monolog (PHP)`](https://github.com/Seldaek/monolog).  
+Теперь используется более [универсальная система логирования](/docs/working-with-the-rest-api/logger/), отчасти похожая на [`Monolog (PHP)`](https://github.com/Seldaek/monolog).  
 
 ```diff
 - import { LoggerBrowser } from '@bitrix24/b24jssdk'

--- a/docs/content/docs/1.getting-started/7.ai/.navigation.yml
+++ b/docs/content/docs/1.getting-started/7.ai/.navigation.yml
@@ -1,1 +1,1 @@
-title: AI Tools
+title: AI-инструменты

--- a/docs/content/docs/1.getting-started/7.ai/1.skills.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.skills.md
@@ -1,6 +1,6 @@
 ---
 title: AI Skills
-description: 'Task-focused skill files for AI coding agents working with @bitrix24/b24jssdk.'
+description: 'Узкоспециализированные skill-файлы для AI-агентов разработчика, работающих с @bitrix24/b24jssdk.'
 audited: 2026-05-29
 navigation.title: Skills
 links:
@@ -12,51 +12,51 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/AGENTS.md
 ---
 
-## Overview {#overview}
+## Обзор {#overview}
 
-AI coding agents (Claude Code, Cursor, GitHub Copilot) can load task-focused skill files from the `skills/` directory instead of reading the entire repository. Each skill covers one concern — pick only what the current task requires.
+AI-агенты для разработки (Claude Code, Cursor, GitHub Copilot) могут загружать узкоспециализированные skill-файлы из директории `skills/` вместо чтения всего репозитория. Каждый skill покрывает одну тему — берите только то, что нужно для текущей задачи.
 
-## Available Skills {#available-skills}
+## Доступные skill'ы {#available-skills}
 
-| Skill | When to use |
+| Skill | Когда использовать |
 |---|---|
-| `b24jssdk-core` | First skill to load — entry point pick (B24Hook / B24Frame / B24OAuth), boot/teardown, error taxonomy, hardErrorCodes / softErrorCodes / retryOnNetworkError tuning |
-| `b24jssdk-rest` | actions.v{2,3}.*.make() — call / batch / callList / fetchList / batchByChunk; AjaxResult shape; v3 method whitelist |
-| `b24jssdk-filtering` | v2 prefix-keyed filter vs v3 array-of-triples; operators; dates via Text.toB24Format; order-stripping rule of callList |
-| `b24jssdk-frame-ui` | iframe-only managers: slider / dialog (selectUser/Users/CRM/Access) / parent / placement (with setValue) / options / auth |
-| `b24jssdk-helpers` | useB24Helper, B24HelperManager, Pull client, currency formatting, app/user options |
-| `b24jssdk-recipes` | 12 end-to-end TypeScript mini-apps, type-checked in CI via pnpm run skills:typecheck |
-| `b24jssdk-vibecode` | When to combine the SDK with the VibeCode HTTP API |
+| `b24jssdk-core` | Первый skill для загрузки — выбор точки входа (B24Hook / B24Frame / B24OAuth), запуск/завершение, классификация ошибок, настройка hardErrorCodes / softErrorCodes / retryOnNetworkError |
+| `b24jssdk-rest` | actions.v{2,3}.*.make() — call / batch / callList / fetchList / batchByChunk; форма AjaxResult; whitelist методов v3 |
+| `b24jssdk-filtering` | Фильтры v2 (ключи с префиксом) vs v3 (массивы триплетов); операторы; даты через Text.toB24Format; правило обрезки order в callList |
+| `b24jssdk-frame-ui` | Менеджеры только для iframe: slider / dialog (selectUser/Users/CRM/Access) / parent / placement (с setValue) / options / auth |
+| `b24jssdk-helpers` | useB24Helper, B24HelperManager, Pull-клиент, форматирование валюты, опции приложения/пользователя |
+| `b24jssdk-recipes` | 12 готовых end-to-end TypeScript мини-приложений, типизация проверяется в CI через pnpm run skills:typecheck |
+| `b24jssdk-vibecode` | Когда комбинировать SDK с HTTP API VibeCode |
 
-## Usage {#usage}
+## Использование {#usage}
 
-Load a skill by referencing it in the agent's context. Examples:
+Загрузите skill, указав его в контексте агента. Примеры:
 
-**Claude Code** — add to the system prompt or reference inline:
+**Claude Code** — добавьте в системный промпт или укажите inline:
 
 ```
 @skills/b24jssdk-core
 ```
 
-**Cursor / Windsurf** — use `@docs` or drag the skill file into the chat context.
+**Cursor / Windsurf** — используйте `@docs` или перетащите файл skill в контекст чата.
 
-**GitHub Copilot** — attach the skill file as a workspace document or paste its path into the chat.
+**GitHub Copilot** — прикрепите файл skill как workspace-документ или вставьте его путь в чат.
 
-Skills are plain Markdown files and can be read directly from `skills/<name>/SKILL.md` in the repository root.
+Skill'ы — это обычные Markdown-файлы и могут читаться напрямую из `skills/<name>/SKILL.md` в корне репозитория.
 
-## Loading Order {#loading-order}
+## Порядок загрузки {#loading-order}
 
-Always start with `b24jssdk-core` — it covers entry point selection and SDK lifecycle, which every other skill assumes. Then add topic-specific skills based on the task:
+Всегда начинайте с `b24jssdk-core` — он покрывает выбор точки входа и жизненный цикл SDK, что предполагают все остальные skill'ы. Затем добавляйте темо-специфичные skill'ы в зависимости от задачи:
 
-1. `b24jssdk-core` (always first)
-2. `b24jssdk-rest` — if making REST calls
-3. `b24jssdk-filtering` — if building filters or list queries
-4. `b24jssdk-frame-ui` — if working inside an iframe app
-5. `b24jssdk-helpers` — if using helper utilities or Pull
-6. `b24jssdk-recipes` — for complete end-to-end examples
+1. `b24jssdk-core` (всегда первый)
+2. `b24jssdk-rest` — если делаете REST-вызовы
+3. `b24jssdk-filtering` — если строите фильтры или list-запросы
+4. `b24jssdk-frame-ui` — если работаете внутри iframe-приложения
+5. `b24jssdk-helpers` — если используете helper-утилиты или Pull
+6. `b24jssdk-recipes` — для готовых end-to-end примеров
 
-Do not load all skills at once — the descriptions are designed for selective consumption to keep the context focused.
+Не загружайте все skill'ы сразу — описания спроектированы для выборочного использования, чтобы контекст оставался сфокусированным.
 
-## Further Reading {#further-reading}
+## Дополнительно {#further-reading}
 
-See [AGENTS.md](https://github.com/bitrix24/b24jssdk/blob/main/AGENTS.md) for full contributor and agent documentation, including commands, testing, and key conventions.
+См. [AGENTS.md](https://github.com/bitrix24/b24jssdk/blob/main/AGENTS.md) — полная документация для контрибьюторов и агентов, включая команды, тестирование и ключевые конвенции.

--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -1,69 +1,69 @@
 ---
 title: LLMs.txt
-description: 'How to get AI tools like Cursor, Windsurf, GitHub Copilot, ChatGPT, and Claude to understand Bitrix24 JS SDK methods, tools, and best practices.'
+description: 'Как сделать, чтобы AI-инструменты вроде Cursor, Windsurf, GitHub Copilot, ChatGPT и Claude понимали методы, инструменты и лучшие практики Bitrix24 JS SDK.'
 audited: 2026-05-29
 links:
-  - label: Nuxt config (nuxt-llms)
+  - label: Конфигурация Nuxt (nuxt-llms)
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/docs/nuxt.config.ts
 ---
 
-## What is LLMs.txt? {#what-is-llmstxt}
+## Что такое LLMs.txt? {#what-is-llmstxt}
 
-LLMs.txt is a structured documentation format specifically designed for large language models (LLMs). Bitrix24 JS SDK provides LLMs.txt files that contain comprehensive information about our component library, making it easy for AI tools to understand and assist with Bitrix24 JS SDK development.
+LLMs.txt — это формат структурированной документации, разработанный специально для больших языковых моделей (LLM). Bitrix24 JS SDK предоставляет LLMs.txt-файлы с исчерпывающей информацией о библиотеке, чтобы AI-инструментам было проще понимать и помогать в разработке с Bitrix24 JS SDK.
 
-These files are optimized for AI consumption and contain structured information about components, APIs, usage patterns, and best practices.
+Эти файлы оптимизированы для потребления AI и содержат структурированную информацию о компонентах, API, паттернах использования и лучших практиках.
 
-## Available Routes {#available-routes}
+## Доступные маршруты {#available-routes}
 
-We provide LLMs.txt routes to help AI tools access our documentation:
+Мы предоставляем LLMs.txt-маршруты, чтобы AI-инструменты могли обращаться к документации:
 
-- **`/llms.txt`** - Contains a structured overview of all components and their documentation links (~5K tokens)
-- **`/llms-full.txt`** - Provides comprehensive documentation including implementation details, examples, theming, composables, and migration guidance (~1M+ tokens)
+- **`/llms.txt`** — содержит структурированный обзор всех компонентов и ссылки на их документацию (~5К токенов)
+- **`/llms-full.txt`** — предоставляет исчерпывающую документацию, включая детали реализации, примеры, тематизацию, composables и руководство по миграции (~1М+ токенов)
 
-## Choosing the Right File {#choosing-the-right-file}
+## Выбор подходящего файла {#choosing-the-right-file}
 
 ::note
-**Most users should start with `/llms.txt`** - it contains all essential information and works with standard LLM context windows.
+**Большинству пользователей следует начать с `/llms.txt`** — он содержит всю необходимую информацию и работает со стандартными контекстными окнами LLM.
 
-Use `/llms-full.txt` only if you need comprehensive implementation examples and your AI tool supports large contexts (200K+ tokens).
+Используйте `/llms-full.txt` только если вам нужны исчерпывающие примеры реализации, а ваш AI-инструмент поддерживает большие контексты (200К+ токенов).
 ::
 
-## Important Usage Notes {#important-usage-notes}
+## Важные замечания по использованию {#important-usage-notes}
 
 ::warning
-**@-symbol must be typed manually** - When using tools like Cursor or Windsurf, the `@` symbol must be typed by hand in the chat interface. Copy-pasting breaks the tool's ability to recognize it as a context reference.
+**Символ @ нужно вводить вручную** — при использовании Cursor или Windsurf символ `@` необходимо набирать руками в интерфейсе чата. Копирование-вставка ломает распознавание этого символа как контекстной ссылки.
 ::
 
-## Usage with AI Tools {#usage-with-ai-tools}
+## Использование с AI-инструментами {#usage-with-ai-tools}
 
 ### Cursor {#cursor}
 
-Bitrix24 JS SDK provides specialized LLMs.txt files that you can reference in Cursor for better AI assistance with component development.
+Bitrix24 JS SDK предоставляет специализированные LLMs.txt-файлы, на которые можно ссылаться в Cursor для улучшения AI-помощи в разработке компонентов.
 
-#### How to use:
+#### Как использовать:
 
-1. **Direct reference**: Mention the LLMs.txt URLs when asking questions
-2. Add these specific URLs to your project context using `@docs`
+1. **Прямая ссылка**: упоминайте URL'ы LLMs.txt при формулировке вопросов
+2. Добавьте эти URL'ы в контекст проекта через `@docs`
 
-[Read more about Cursor Web and Docs Search](https://docs.cursor.com/en/context/@-symbols/@-docs)
+[Подробнее о Cursor Web and Docs Search](https://docs.cursor.com/en/context/@-symbols/@-docs)
 
 ### Windsurf {#windsurf}
 
-Windsurf can directly access the Bitrix24 JS SDK LLMs.txt files to understand component usage and best practices.
+Windsurf может напрямую обращаться к LLMs.txt-файлам Bitrix24 JS SDK для понимания использования компонентов и лучших практик.
 
-#### Using LLMs.txt with Windsurf:
+#### Использование LLMs.txt с Windsurf:
 
-- Use `@docs` to reference specific LLMs.txt URLs
-- Create persistent rules referencing these URLs in your workspace
+- Используйте `@docs` для ссылки на конкретные URL'ы LLMs.txt
+- Создавайте постоянные правила, ссылающиеся на эти URL'ы, в вашем workspace
 
-[Read more about Windsurf Web and Docs Search](https://docs.windsurf.com/windsurf/cascade/web-search)
+[Подробнее о Windsurf Web and Docs Search](https://docs.windsurf.com/windsurf/cascade/web-search)
 
-### Other AI Tools {#other-ai-tools}
+### Другие AI-инструменты {#other-ai-tools}
 
-Any AI tool that supports LLMs.txt can use these routes to better understand Bitrix24 JS SDK.
+Любой AI-инструмент с поддержкой LLMs.txt может использовать эти маршруты для лучшего понимания Bitrix24 JS SDK.
 
-#### Examples for ChatGPT, Claude, or other LLMs:
+#### Примеры для ChatGPT, Claude и других LLM:
 
-- "Using Bitrix24 JS SDK documentation from https://bitrix24.github.io/b24jssdk/llms.txt"
-- "Follow complete Bitrix24 JS SDK guidelines from https://bitrix24.github.io/b24jssdk/llms-full.txt"
+- «Используя документацию Bitrix24 JS SDK из https://bitrix24.github.io/b24jssdk/llms.txt»
+- «Следуйте полному руководству Bitrix24 JS SDK из https://bitrix24.github.io/b24jssdk/llms-full.txt»


### PR DESCRIPTION
## Кратко

**Stage 3b** — полный перевод `docs/content/docs/1.getting-started/**` на русский язык. 11 файлов, +368/-368 строк (равенство — переписан весь EN на RU практически 1-в-1 по объёму).

Это первый «контентный» PR (Stage 1–4 были инфраструктурными). С этого момента сайт начинает выглядеть как русскоязычная документация для нового пользователя.

## Что переведено

### `1.getting-started/`

| Файл | Что сделано |
|---|---|
| `.navigation.yml` | `Get Started` → `Начало работы` |
| `1.index.md` | Главная страница раздела — обзор SDK, выбор класса (B24Frame/B24Hook/B24OAuth), первые шаги с API, советы для начинающих, спорные пункты согласованы |

### `2.installation/` (5 файлов)

| Файл | Что сделано |
|---|---|
| `1.vue.md` | `Vue Project` → `Проект на Vue` |
| `2.nuxt.md` | `Nuxt Project` → `Проект на Nuxt` + примечание про Nuxt 4 |
| `3.react.md` | `React Project` → `Проект на React` + bullet-list «Ключевые особенности React» переведён |
| `4.nodejs.md` | `Node.js Project` → `Проект на Node.js` + примечание про CommonJs и поддерживаемые версии |
| `5.umd.md` | `UMD` (без перевода, термин) + полностью переведены оба HTML-примера (`rest-api-ver2` / `rest-api-ver3`) с педагогическими комментариями |

### `3.migration/` (1 файл)

| Файл | Что сделано |
|---|---|
| `1.v1.md` | `Migration to v1` → `Миграция на v1`; `navigation.title: v0 to v1` → `v0 → v1`; разделы `Change/Removed/Deprecated` → `Изменения/Удалено/Устарело`; все блок-цитаты с описанием методов переведены; все diff-блоки и API-сигнатуры нетронуты |

### `7.ai/` (3 файла)

| Файл | Что сделано |
|---|---|
| `.navigation.yml` | `AI Tools` → `AI-инструменты` |
| `1.skills.md` | `AI Skills` (термин Claude Code — не переводим) + полное описание 7 skill'ов (`b24jssdk-core`, `b24jssdk-rest`, `b24jssdk-filtering`, и пр.) |
| `2.llms-txt.md` | `LLMs.txt` (термин) + руководство для Cursor/Windsurf/ChatGPT/Claude; URL-ы примеров на `bitrix24.github.io` (upstream) оставлены — там полный текст для AI |

### Не тронуто

- `3.migration/.navigation.yml` = `shadow: false` — служебный флаг, без перевода

## Что НЕ переведено по правилам (применено везде)

- **Якоря `{#en-anchor}`** — стабильные URL, нетронуты
- **Имена SDK**: `B24Frame`, `B24Hook`, `B24OAuth`, `EnumAppStatus`, `EnumCrmEntityTypeId`, `LoggerFactory`, `AjaxResult`, `SdkError`, `PlacementManager`, `TypeB24`, `TypeHttp`, `AbstractB24`, `ApiVersion`, `Text`, `B24Js` (UMD-namespace)
- **API-методы**: `crm.contact.list`, `crm.deal.add`, `crm.item.list`, `user.current`, `tasks.task.list` — нетронуты
- **TypeScript типы и сигнатуры** — `B24Frame`, `ISODate`, `Promise<Company[]>`, etc.
- **npm-пакеты**: `@bitrix24/b24jssdk`, `@bitrix24/b24jssdk-nuxt`
- **Логи** (`console.log/error`, `logger.debug/info/notice/error`, `throw new Error`) — английские для предсказуемости фильтров логов (правило AGENTS.md)
- **JSX-разметка** в React-примере (`<h1>`, `<p>`) — часть кода-примера, не комментарий
- **HTML-разметка** в UMD-примере (`<h1>`, `<title>`, `<p>`) — то же
- **diff-блоки** в migration v1 — `- старый` / `+ новый` синтаксис нетронут, переведены только окружающие абзацы
- **`{lang="ts-type"}`, `{level="3"}`, `{sync="pm"}`, `{class="mt-0"}`** — MDC-параметры
- **`Client ID` / `Client Secret`** — `keep_en: true` по glossary

## Согласованные стилистические решения (из ревью index.md)

| Решение | Применено |
|---|---|
| `Get Started` → `Начало работы` (не `Начать` — это раздел доки, не UI-кнопка) | везде |
| `batches of 50 elements` → `пачками по 50 элементов` (не «батчами» — здесь не пакетные запросы) | index.md |
| `Open an issue on GitHub` → `Открыть issue в GitHub` | index.md |
| `unix timestamp, seconds` → `unix timestamp, секунды` | везде |
| `webhook` → `вебхук` (glossary) | везде |
| `Settings → Developers → Webhooks` → `Настройки → Разработчикам → Вебхуки` | везде |
| `Settings → Developers → Applications` → `Настройки → Разработчикам → Приложения` | везде |
| `⚠️ SECURITY` → `⚠️ БЕЗОПАСНОСТЬ` в caution-боксах | везде |
| `For the client side, use [B24Frame]` → `Для клиентской стороны используйте [B24Frame]` | везде |
| `callback` → `callback` (glossary `keep_en`) | везде |
| `placement` → `placement` (glossary `keep_en`) | везде |
| `composable` → `composable` (glossary `keep_en`) | везде |

## CI

- ✅ `lint` — 0 ошибок
- ✅ `typecheck` — `nuxt prepare` + `vue-tsc` — 0 ошибок
- ✅ `build` — `docs:generate` — статический экспорт собран

## Чеклист проверки

### Стиль и согласованность

- [ ] Стиль перевода (формальный тон, «вы» с маленькой, ёлочки) одинаков во всех 11 файлах
- [x] Терминология (вебхук, батч, чанк) применена по glossary
- [ ] Якоря `{#en-anchor}` сохранены везде — `grep -rE '\{#[а-я]' docs/content/docs/1.getting-started/` пуст

### Контент

- [x] Нет потерянных абзацев vs EN-оригинал (сверить с upstream на коммите-источнике)
- [x] Имена классов SDK нигде не переведены — `grep -E '(КлиентB24|Вебхук[А-Я]|Битрикс24-?Hook)' docs/content/docs/1.getting-started/` пуст
- [x] `console.log/error`, `logger.*`, `throw new Error` строки английские

### Сборка

- [x] `pnpm run docs:dev` — все страницы рендерятся без ошибок MDC
- [x] `pnpm run docs:generate` — static export проходит
- [x] Откройте локально:
  - `/docs/getting-started/` (главная)
  - `/docs/getting-started/installation/vue/`
  - `/docs/getting-started/installation/nuxt/`
  - `/docs/getting-started/installation/react/`
  - `/docs/getting-started/installation/nodejs/`
  - `/docs/getting-started/installation/umd/`
  - `/docs/getting-started/migration/v1/`
  - `/docs/getting-started/ai/skills/`
  - `/docs/getting-started/ai/llms-txt/`
- [x] Боковое меню показывает RU-названия («Начало работы», «AI-инструменты», «v0 → v1»)
- [x] MDC-блоки рендерятся: `::warning`, `::note`, `::caution`, `::tabs`, `::tabs-item`, `::code-group`, `::steps`, `::rest-api-version-only`
- [x] Якоря в ToC бокового меню — английские slug

### Платформы

- [x] Linux/macOS
- [x] Windows (если переводчик/тестировщик на Windows)

## Что дальше

После мержа Stage 3b → **Stage 3c**: `docs/content/docs/2.working-with-the-rest-api/**` (53 файла, ядро REST API). Это самый большой блок перевода.

## Файлы в этом PR

```
docs/content/docs/1.getting-started/.navigation.yml
docs/content/docs/1.getting-started/1.index.md
docs/content/docs/1.getting-started/2.installation/1.vue.md
docs/content/docs/1.getting-started/2.installation/2.nuxt.md
docs/content/docs/1.getting-started/2.installation/3.react.md
docs/content/docs/1.getting-started/2.installation/4.nodejs.md
docs/content/docs/1.getting-started/2.installation/5.umd.md
docs/content/docs/1.getting-started/3.migration/1.v1.md
docs/content/docs/1.getting-started/7.ai/.navigation.yml
docs/content/docs/1.getting-started/7.ai/1.skills.md
docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
```