### PR TITLE
Stage 3c · PR-B: translate working-with-rest-api — entry points &amp; managers (hook/oauth/frame/helper)

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/20.hook.md
+++ b/docs/content/docs/2.working-with-the-rest-api/20.hook.md
@@ -1,6 +1,6 @@
 ---
-title: B24Hook Class
-description: 'Server-side entry point for talking to the Bitrix24 REST API through an inbound webhook (permanent token).'
+title: Класс B24Hook
+description: 'Серверная точка входа для работы с REST API Bitrix24 через входящий вебхук (постоянный токен).'
 category: 'B24Hook'
 navigation.title: B24Hook
 links:
@@ -15,27 +15,27 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts
 ---
 
-::caution{title="⚠️ CAUTION: SECURITY"}
-The `B24Hook`{lang="ts-type"} object is intended **exclusively for use on the server**.
+::caution{title="⚠️ ВНИМАНИЕ: БЕЗОПАСНОСТЬ"}
+Объект `B24Hook`{lang="ts-type"} предназначен **исключительно для использования на сервере**.
 
-- A webhook URL contains a secret access key. **It must never appear in client-side code (browser, mobile app)**.
-- For the client side, use [`B24Frame`](/docs/working-with-the-rest-api/frame/).
-- The HTTP client is created with a client-side warning enabled by default — see [`offClientSideWarning`](#offclientsidewarning).
+- URL вебхука содержит секретный ключ доступа. **Он никогда не должен попадать в клиентский код (браузер, мобильное приложение)**.
+- Для клиентской стороны используйте [`B24Frame`](/docs/working-with-the-rest-api/frame/).
+- HTTP-клиент по умолчанию создаётся с включённым предупреждением о клиентской стороне — см. [`offClientSideWarning`](#offclientsidewarning).
 ::
 
-## Overview {#overview}
+## Обзор {#overview}
 
-`B24Hook`{lang="ts-type"} is the SDK class for working with the Bitrix24 REST API through an inbound webhook. A webhook is a URL that already carries the user identifier and a secret token, so requests authenticate without an OAuth handshake.
+`B24Hook`{lang="ts-type"} — это класс SDK для работы с REST API Bitrix24 через входящий вебхук. Вебхук — это URL, который уже содержит идентификатор пользователя и секретный токен, поэтому запросы аутентифицируются без OAuth-рукопожатия.
 
-The class extends `AbstractB24`{lang="ts-type"} and implements [`TypeB24`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts), so the full REST surface (`actions.v2.*`, `actions.v3.*`, `tools.*`) is available immediately after construction — there is no `await b24.init()` step.
+Класс наследуется от `AbstractB24`{lang="ts-type"} и реализует [`TypeB24`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts), поэтому полный набор REST-методов (`actions.v2.*`, `actions.v3.*`, `tools.*`) доступен сразу после создания экземпляра — шаг `await b24.init()` не требуется.
 
-## Creating a B24Hook Instance {#creating-a-b24hook-instance}
+## Создание экземпляра B24Hook {#creating-a-b24hook-instance}
 
-There are two ways to create a `B24Hook`{lang="ts-type"} instance.
+Создать экземпляр `B24Hook`{lang="ts-type"} можно двумя способами.
 
-### From a Full Webhook URL {#from-a-full-webhook-url}
+### Из полного URL вебхука {#from-a-full-webhook-url}
 
-Recommended approach when the webhook URL is stored as a single environment variable.
+Рекомендуемый способ, когда URL вебхука хранится в одной переменной окружения.
 
 ```ts
 import { B24Hook } from '@bitrix24/b24jssdk'
@@ -43,7 +43,7 @@ import { B24Hook } from '@bitrix24/b24jssdk'
 const $b24 = B24Hook.fromWebhookUrl('https://your_domain.bitrix24.com/rest/1/k32t88gf3azpmwv3/')
 ```
 
-#### Method Signature
+#### Сигнатура метода
 
 ```ts-type
 static fromWebhookUrl(
@@ -52,18 +52,18 @@ static fromWebhookUrl(
 ): B24Hook
 ```
 
-#### Parameters
+#### Параметры
 
-| Parameter | Type | Required | Description |
+| Параметр | Тип | Обязательный | Описание |
 |----|----|----|----|
-| `url` | `string`{lang="ts-type"} | Yes | Full webhook URL. Both URL formats are supported: `/rest/<userId>/<secret>` (REST v2) and `/rest/api/<userId>/<secret>` (REST v3). |
-| `options.restrictionParams` | `Partial<RestrictionParams>`{lang="ts-type"} | No | Override of the default rate-limit / operating-limit / adaptive-delay configuration. See [Limiters](/docs/working-with-the-rest-api/limiters/). |
+| `url` | `string`{lang="ts-type"} | Да | Полный URL вебхука. Поддерживаются оба формата URL: `/rest/<userId>/<secret>` (REST v2) и `/rest/api/<userId>/<secret>` (REST v3). |
+| `options.restrictionParams` | `Partial<RestrictionParams>`{lang="ts-type"} | Нет | Переопределение конфигурации rate limit / operating limit / адаптивной задержки, заданной по умолчанию. См. [Лимитеры](/docs/working-with-the-rest-api/limiters/). |
 
-The static factory validates the URL: HTTPS is required, the path must match one of the supported shapes, and the user id must be numeric. Anything else throws synchronously.
+Статическая фабрика валидирует URL: требуется HTTPS, путь должен соответствовать одному из поддерживаемых форматов, а идентификатор пользователя должен быть числовым. Всё остальное синхронно выбрасывает исключение.
 
-### From Parameters {#from-parameters}
+### Из параметров {#from-parameters}
 
-Use this constructor when webhook parts are stored separately (for example: portal URL in one env var, token in a secrets manager).
+Используйте этот конструктор, когда части вебхука хранятся раздельно (например: URL портала в одной переменной окружения, токен — в менеджере секретов).
 
 ```ts
 import { B24Hook } from '@bitrix24/b24jssdk'
@@ -75,7 +75,7 @@ const $b24 = new B24Hook({
 })
 ```
 
-#### Constructor Signature
+#### Сигнатура конструктора
 
 ```ts-type
 constructor(
@@ -84,15 +84,15 @@ constructor(
 )
 ```
 
-#### `B24HookParams` Fields
+#### Поля `B24HookParams`
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `b24Url` | `string`{lang="ts-type"} | Bitrix24 portal URL (`https://your_domain.bitrix24.com`). |
-| `userId` | `number`{lang="ts-type"} | Identifier of the user the webhook belongs to. |
-| `secret` | `string`{lang="ts-type"} | Webhook secret token. |
+| `b24Url` | `string`{lang="ts-type"} | URL портала Bitrix24 (`https://your_domain.bitrix24.com`). |
+| `userId` | `number`{lang="ts-type"} | Идентификатор пользователя, которому принадлежит вебхук. |
+| `secret` | `string`{lang="ts-type"} | Секретный токен вебхука. |
 
-## Quick Example {#quick-example}
+## Быстрый пример {#quick-example}
 
 ```ts
 import { B24Hook, EnumCrmEntityTypeId, LoggerFactory } from '@bitrix24/b24jssdk'
@@ -122,7 +122,7 @@ if (!response.isSuccess) {
 $logger.info('Companies', response.getData()?.result)
 ```
 
-## Getters {#getters}
+## Геттеры {#getters}
 
 ### `auth` {#auth}
 
@@ -130,12 +130,12 @@ $logger.info('Companies', response.getData()?.result)
 get auth(): AuthActions
 ```
 
-Returns the [`AuthHookManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/hook/auth.ts) instance, which implements [`AuthActions`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts):
+Возвращает экземпляр [`AuthHookManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/hook/auth.ts), который реализует [`AuthActions`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts):
 
-- `getAuthData()` — returns synthetic `AuthData`{lang="ts-type"} composed from the webhook secret. `expires` is always `0` (webhook tokens do not expire).
-- `refreshAuth()` — for compatibility with `B24OAuth`{lang="ts-type"}; returns the same data without performing a network call.
-- `getUniq(prefix: string)` — returns `<prefix>_<member_id>`{lang="ts-type"}, used by the Pull client and other helpers.
-- `isAdmin` — always `true`{lang="ts-type"} (webhooks are assumed to be created by admins).
+- `getAuthData()` — возвращает синтетический `AuthData`{lang="ts-type"}, собранный из секрета вебхука. `expires` всегда равен `0` (токены вебхуков не истекают).
+- `refreshAuth()` — для совместимости с `B24OAuth`{lang="ts-type"}; возвращает те же данные без сетевого запроса.
+- `getUniq(prefix: string)` — возвращает `<prefix>_<member_id>`{lang="ts-type"}, используется Pull-клиентом и другими хелперами.
+- `isAdmin` — всегда `true`{lang="ts-type"} (предполагается, что вебхуки создаются администраторами).
 
 ### `isInit` {#isinit}
 
@@ -143,11 +143,11 @@ Returns the [`AuthHookManager`](https://github.com/bitrix24/b24jssdk/blob/main/p
 get isInit(): boolean
 ```
 
-Always `true`{lang="ts-type"} immediately after construction — no `init()` call is required for `B24Hook`{lang="ts-type"}.
+Всегда `true`{lang="ts-type"} сразу после создания экземпляра — вызов `init()` для `B24Hook`{lang="ts-type"} не требуется.
 
 ### `actions` / `tools` {#actions-tools}
 
-Same shape as on every `TypeB24`{lang="ts-type"} class. See:
+Та же структура, что и у каждого класса `TypeB24`{lang="ts-type"}. См.:
 
 - [`CallV2.make`](/docs/working-with-the-rest-api/call-rest-api-ver2/) / [`CallV3.make`](/docs/working-with-the-rest-api/call-rest-api-ver3/)
 - [`CallListV2.make`](/docs/working-with-the-rest-api/call-list-rest-api-ver2/) / [`CallListV3.make`](/docs/working-with-the-rest-api/call-list-rest-api-ver3/)
@@ -156,7 +156,7 @@ Same shape as on every `TypeB24`{lang="ts-type"} class. See:
 - [`BatchByChunkV2.make`](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/) / [`BatchByChunkV3.make`](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver3/)
 - [`tools.healthCheck.make`](/docs/working-with-the-rest-api/tools-health-check/), [`tools.ping.make`](/docs/working-with-the-rest-api/tools-ping/)
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### `getTargetOrigin` {#gettargetorigin}
 
@@ -164,7 +164,7 @@ Same shape as on every `TypeB24`{lang="ts-type"} class. See:
 getTargetOrigin(): string
 ```
 
-Returns the portal origin (`https://your_domain.bitrix24.com`).
+Возвращает origin портала (`https://your_domain.bitrix24.com`).
 
 ### `getTargetOriginWithPath` {#gettargetoriginwithpath}
 
@@ -172,7 +172,7 @@ Returns the portal origin (`https://your_domain.bitrix24.com`).
 getTargetOriginWithPath(): Map<ApiVersion, string>
 ```
 
-Returns the per-version REST endpoint:
+Возвращает REST-endpoint для каждой версии:
 
 - `ApiVersion.v2`{lang="ts-type"} → `https://your_domain.bitrix24.com/rest/<userId>/<secret>`
 - `ApiVersion.v3`{lang="ts-type"} → `https://your_domain.bitrix24.com/rest/api/<userId>/<secret>`
@@ -183,7 +183,7 @@ Returns the per-version REST endpoint:
 offClientSideWarning(): void
 ```
 
-Disables the runtime warning emitted by both HTTP clients when `B24Hook`{lang="ts-type"} is detected in a browser environment. Use only when you intentionally proxy the webhook through a server-side wrapper that strips the secret before any browser request.
+Отключает runtime-предупреждение, которое оба HTTP-клиента выводят при обнаружении `B24Hook`{lang="ts-type"} в браузерном окружении. Используйте только если вы намеренно проксируете вебхук через серверную обёртку, которая удаляет секрет до любого запроса из браузера.
 
 ### `getHttpClient` / `setHttpClient` {#gethttpclient-sethttpclient}
 
@@ -192,7 +192,7 @@ getHttpClient(version: ApiVersion): TypeHttp
 setHttpClient(version: ApiVersion, client: TypeHttp): void
 ```
 
-Direct access to the underlying HTTP transports (one per REST API version). See [Http reference](/docs/working-with-the-rest-api/core-http/).
+Прямой доступ к нижележащим HTTP-транспортам (по одному на каждую версию REST API). См. [справочник Http](/docs/working-with-the-rest-api/core-http/).
 
 ### `setRestrictionManagerParams` {#setrestrictionmanagerparams}
 
@@ -200,7 +200,7 @@ Direct access to the underlying HTTP transports (one per REST API version). See 
 setRestrictionManagerParams(params: RestrictionParams): Promise<void>
 ```
 
-Replaces the rate-limit / operating-limit / adaptive-delay configuration on both v2 and v3 clients at once. See [Limiters](/docs/working-with-the-rest-api/limiters/).
+Заменяет конфигурацию rate limit / operating limit / адаптивной задержки сразу на клиентах v2 и v3. См. [Лимитеры](/docs/working-with-the-rest-api/limiters/).
 
 ### `getLogger` / `setLogger` {#getlogger-setlogger}
 
@@ -209,7 +209,7 @@ getLogger(): LoggerInterface
 setLogger(logger: LoggerInterface): void
 ```
 
-Get or replace the logger used by the SDK and propagated into the HTTP clients. See [Logger](/docs/working-with-the-rest-api/logger/).
+Получает или заменяет логгер, используемый SDK и передаваемый в HTTP-клиенты. См. [Логгер](/docs/working-with-the-rest-api/logger/).
 
 ### `destroy` {#destroy}
 
@@ -217,7 +217,7 @@ Get or replace the logger used by the SDK and propagated into the HTTP clients. 
 destroy(): void
 ```
 
-Releases internal references. Call before the process exits or when discarding a long-lived instance.
+Освобождает внутренние ссылки. Вызывайте перед завершением процесса или при удалении долгоживущего экземпляра.
 
 ```ts
 function shutdown() {
@@ -225,14 +225,14 @@ function shutdown() {
 }
 ```
 
-## Storing the Webhook Secret {#storing-the-webhook-secret}
+## Хранение секрета вебхука {#storing-the-webhook-secret}
 
 // @check-ignore: partial snippet — illustrates env vs inline URL pattern
 ```ts
-// ✅ Server-side env variable
+// ✅ Серверная переменная окружения
 const $b24ok = B24Hook.fromWebhookUrl(process.env.BITRIX24_WEBHOOK_URL!)
 
-// ❌ Never inline the URL in client code or commit it to Git
+// ❌ Никогда не вставляйте URL в клиентский код и не коммитьте его в Git
 const $b24bad = B24Hook.fromWebhookUrl(
   'https://company.bitrix24.com/rest/1/abcdef123456/'
 )
@@ -242,20 +242,20 @@ const $b24bad = B24Hook.fromWebhookUrl(
 
 ::accordion
 
-:::accordion-item{label="Where do I get the webhook URL?"}
-Bitrix24 → Settings → Developers → Webhooks → Inbound webhook. See the [official documentation](https://apidocs.bitrix24.ru/local-integrations/local-webhooks.html#vhodyashij-vebhuk).
+:::accordion-item{label="Где взять URL вебхука?"}
+Bitrix24 → Настройки → Разработчикам → Вебхуки → Входящий вебхук. См. [официальную документацию](https://apidocs.bitrix24.ru/local-integrations/local-webhooks.html#vhodyashij-vebhuk).
 :::
 
-:::accordion-item{label="Can one B24Hook instance serve the whole server?"}
-Yes. Create the instance once at startup and share it across requests — the HTTP clients reuse the underlying axios instance and the limiter state.
+:::accordion-item{label="Может ли один экземпляр B24Hook обслуживать весь сервер?"}
+Да. Создайте экземпляр один раз при запуске и переиспользуйте его между запросами — HTTP-клиенты переиспользуют общий экземпляр axios и состояние лимитера.
 :::
 
-:::accordion-item{label="Why does fromWebhookUrl throw 'Webhook requires HTTPS protocol'?"}
-The factory rejects `http://` URLs by design. Webhook secrets must travel over TLS.
+:::accordion-item{label="Почему fromWebhookUrl выбрасывает „Webhook requires HTTPS protocol“?"}
+Фабрика намеренно отклоняет `http://`-URL. Секреты вебхуков должны передаваться по TLS.
 :::
 
-:::accordion-item{label="What does 'Access denied' mean?"}
-The webhook user lacks permissions for the called REST method, or the webhook itself was revoked. Recreate the webhook with the required scopes.
+:::accordion-item{label="Что означает „Access denied“?"}
+У пользователя вебхука нет прав на вызванный REST-метод, либо сам вебхук был отозван. Пересоздайте вебхук с необходимыми scope.
 :::
 
 ::

--- a/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
@@ -1,9 +1,9 @@
 ---
-title: B24Frame Initialization
-description: 'Function is designed to initialize a B24Frame'
+title: Инициализация B24Frame
+description: 'Функция предназначена для инициализации B24Frame'
 category: 'B24Frame'
 audited: 2026-05-29
-navigation.title: Initialization
+navigation.title: Инициализация
 links:
   - label: initializeB24Frame
     iconName: GitHubIcon
@@ -14,26 +14,26 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
 ```ts-type
 initializeB24Frame(): Promise<B24Frame>
 ```
 
-The `initializeB24Frame` function is designed to initialize a [`B24Frame`](/docs/working-with-the-rest-api/frame/) object, which is used for working with Bitrix24 applications.
+Функция `initializeB24Frame` предназначена для инициализации объекта [`B24Frame`](/docs/working-with-the-rest-api/frame/), который используется для работы с приложениями Bitrix24.
 
-It manages the initialization process and handles potential connection errors.
+Она управляет процессом инициализации и обрабатывает возможные ошибки соединения.
 
 ::note
-Supports repeated calls until initialization is complete, using a callback queue.
+Поддерживает повторные вызовы до завершения инициализации, используя очередь callback-ов.
 ::
 
-**Return Value**
+**Возвращаемое значение**
 
-- **`Promise<B24Frame>`**: Returns a promise that resolves to a [`B24Frame`](/docs/working-with-the-rest-api/frame/) object upon successful initialization.
+- **`Promise<B24Frame>`**: возвращает promise, который при успешной инициализации разрешается объектом [`B24Frame`](/docs/working-with-the-rest-api/frame/).
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import { initializeB24Frame } from '@bitrix24/b24jssdk'

--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -1,8 +1,8 @@
 ---
-title: B24Frame Class
-description: 'Designed for managing Bitrix24 applications running inside a placement iframe. Inherits from AbstractB24 and exposes managers for authentication, parent-window messaging, sliders, dialogs, placements, and options.'
+title: Класс B24Frame
+description: 'Предназначен для управления приложениями Bitrix24, работающими внутри placement-iframe. Наследуется от AbstractB24 и предоставляет менеджеры для аутентификации, обмена сообщениями с родительским окном, слайдеров, диалогов, placement и опций.'
 category: 'B24Frame'
-navigation.title: Introduction
+navigation.title: Введение
 links:
   - label: B24Frame
     iconName: GitHubIcon
@@ -13,12 +13,12 @@ links:
 ---
 
 ::note
-You should not call `new B24Frame(...)`{lang="ts-type"} directly — use [`initializeB24Frame()`](/docs/working-with-the-rest-api/frame-initialize-b24-frame/), which deduplicates concurrent inits, parses the `window.name` payload from Bitrix24, and `await`s `init()` for you.
+Не вызывайте `new B24Frame(...)`{lang="ts-type"} напрямую — используйте [`initializeB24Frame()`](/docs/working-with-the-rest-api/frame-initialize-b24-frame/), которая устраняет дублирование параллельных инициализаций, разбирает payload из `window.name` от Bitrix24 и сама выполняет `await` для `init()`.
 ::
 
-`B24Frame`{lang="ts-type"} extends `AbstractB24`{lang="ts-type"} and implements [`TypeB24`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts). On top of the shared REST surface (`actions.v2.*`, `actions.v3.*`, `tools.*`) it exposes managers that talk to the parent window through `postMessage`: `auth`, `parent`, `slider`, `dialog`, `placement`, `options`.
+`B24Frame`{lang="ts-type"} наследуется от `AbstractB24`{lang="ts-type"} и реализует [`TypeB24`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts). Поверх общего набора REST-методов (`actions.v2.*`, `actions.v3.*`, `tools.*`) он предоставляет менеджеры, которые общаются с родительским окном через `postMessage`: `auth`, `parent`, `slider`, `dialog`, `placement`, `options`.
 
-## Constructor {#constructor}
+## Конструктор {#constructor}
 
 ```ts-type
 constructor(
@@ -27,18 +27,18 @@ constructor(
 )
 ```
 
-[`B24FrameQueryParams`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts) describes the Bitrix24-supplied identifiers parsed from `window.name`:
+[`B24FrameQueryParams`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts) описывает предоставляемые Bitrix24 идентификаторы, разобранные из `window.name`:
 
-| Field      | Type      | Description                        |
+| Поле       | Тип       | Описание                           |
 |------------|-----------|------------------------------------|
-| `DOMAIN`   | `string`{lang="ts-type"}  | Bitrix24 portal domain.              |
-| `PROTOCOL` | `boolean`{lang="ts-type"} | Connection protocol flag.            |
-| `LANG`     | `string`{lang="ts-type"}  | Bitrix24 interface language.         |
-| `APP_SID`  | `string`{lang="ts-type"}  | Application session identifier.      |
+| `DOMAIN`   | `string`{lang="ts-type"}  | Домен портала Bitrix24.              |
+| `PROTOCOL` | `boolean`{lang="ts-type"} | Флаг протокола соединения.           |
+| `LANG`     | `string`{lang="ts-type"}  | Язык интерфейса Bitrix24.            |
+| `APP_SID`  | `string`{lang="ts-type"}  | Идентификатор сессии приложения.     |
 
-Unlike `B24Hook`{lang="ts-type"} and `B24OAuth`{lang="ts-type"}, `B24Frame`{lang="ts-type"} requires `await b24.init()` before any REST call — `init()` performs the `getInitData` handshake with the parent window. `initializeB24Frame()` does this for you.
+В отличие от `B24Hook`{lang="ts-type"} и `B24OAuth`{lang="ts-type"}, `B24Frame`{lang="ts-type"} требует `await b24.init()` перед любым REST-вызовом — `init()` выполняет рукопожатие `getInitData` с родительским окном. `initializeB24Frame()` делает это за вас.
 
-## Getters {#getters}
+## Геттеры {#getters}
 
 ### `isInit` {#isinit}
 
@@ -46,7 +46,7 @@ Unlike `B24Hook`{lang="ts-type"} and `B24OAuth`{lang="ts-type"}, `B24Frame`{lang
 get isInit(): boolean
 ```
 
-`true`{lang="ts-type"} once the parent-window handshake completes. Until then, accessing `auth`, `actions`, `tools`, or any frame manager throws `'B24 not initialized'`{lang="ts-type"}.
+`true`{lang="ts-type"} после завершения рукопожатия с родительским окном. До этого обращение к `auth`, `actions`, `tools` или любому менеджеру фрейма выбрасывает `'B24 not initialized'`{lang="ts-type"}.
 
 ### `isFirstRun` {#isfirstrun}
 
@@ -54,7 +54,7 @@ get isInit(): boolean
 get isFirstRun(): boolean
 ```
 
-`true`{lang="ts-type"} on the very first launch of the application (Bitrix24 sets `FIRST_RUN`). On `isFirstRun = true`{lang="ts-type"}, the SDK automatically sends `setInstall: true` to the parent.
+`true`{lang="ts-type"} при самом первом запуске приложения (Bitrix24 устанавливает `FIRST_RUN`). При `isFirstRun = true`{lang="ts-type"} SDK автоматически отправляет `setInstall: true` родительскому окну.
 
 ### `isInstallMode` {#isinstallmode}
 
@@ -62,7 +62,7 @@ get isFirstRun(): boolean
 get isInstallMode(): boolean
 ```
 
-`true`{lang="ts-type"} while the application is in installation flow (`INSTALL` flag from the parent). Required by [`installFinish`](#installfinish).
+`true`{lang="ts-type"} пока приложение находится в процессе установки (флаг `INSTALL` от родителя). Требуется для [`installFinish`](#installfinish).
 
 ### `auth` {#auth}
 
@@ -70,7 +70,7 @@ get isInstallMode(): boolean
 get auth(): AuthManager
 ```
 
-[Authorization manager](/docs/working-with-the-rest-api/frame-auth/). Exposes `getAuthData`, `refreshAuth`, `getUniq`, `isAdmin`, plus auto-refresh on 401 responses.
+[Менеджер авторизации](/docs/working-with-the-rest-api/frame-auth/). Предоставляет `getAuthData`, `refreshAuth`, `getUniq`, `isAdmin`, а также автообновление при ответах 401.
 
 ### `parent` {#parent}
 
@@ -78,7 +78,7 @@ get auth(): AuthManager
 get parent(): ParentManager
 ```
 
-[Parent window manager](/docs/working-with-the-rest-api/frame-parent/). Posting messages to and reading metadata from the surrounding Bitrix24 page.
+[Менеджер родительского окна](/docs/working-with-the-rest-api/frame-parent/). Отправка сообщений в окружающую страницу Bitrix24 и чтение её метаданных.
 
 ### `slider` {#slider}
 
@@ -86,7 +86,7 @@ get parent(): ParentManager
 get slider(): SliderManager
 ```
 
-[Slider manager](/docs/working-with-the-rest-api/frame-slider/). Open / close Bitrix24 sliders.
+[Менеджер слайдеров](/docs/working-with-the-rest-api/frame-slider/). Открытие и закрытие слайдеров Bitrix24.
 
 ### `placement` {#placement}
 
@@ -94,7 +94,7 @@ get slider(): SliderManager
 get placement(): PlacementManager
 ```
 
-[Placement manager](/docs/working-with-the-rest-api/frame-placement/). Inspect and update the placement context.
+[Менеджер placement](/docs/working-with-the-rest-api/frame-placement/). Просмотр и обновление контекста placement.
 
 ### `options` {#options}
 
@@ -102,7 +102,7 @@ get placement(): PlacementManager
 get options(): OptionsManager
 ```
 
-[Options manager](/docs/working-with-the-rest-api/frame-options/). Read application / user options synced from the parent window.
+[Менеджер опций](/docs/working-with-the-rest-api/frame-options/). Чтение опций приложения и пользователя, синхронизированных из родительского окна.
 
 ### `dialog` {#dialog}
 
@@ -110,9 +110,9 @@ get options(): OptionsManager
 get dialog(): DialogManager
 ```
 
-[Dialog manager](/docs/working-with-the-rest-api/frame-dialog/). Ask Bitrix24 to render its native confirm / message / file pickers.
+[Менеджер диалогов](/docs/working-with-the-rest-api/frame-dialog/). Запрос к Bitrix24 на отображение нативных диалогов подтверждения / сообщений / выбора файлов.
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### `init` {#init}
 
@@ -120,7 +120,7 @@ get dialog(): DialogManager
 init(): Promise<void>
 ```
 
-Performs the parent-window handshake (`getInitData`), wires the manager state, and creates both REST API HTTP clients. Idempotent in practice — `initializeB24Frame()` deduplicates concurrent calls.
+Выполняет рукопожатие с родительским окном (`getInitData`), настраивает состояние менеджеров и создаёт оба HTTP-клиента REST API. На практике идемпотентен — `initializeB24Frame()` устраняет дублирование параллельных вызовов.
 
 ### `destroy` {#destroy}
 
@@ -128,7 +128,7 @@ Performs the parent-window handshake (`getInitData`), wires the manager state, a
 destroy(): void
 ```
 
-Unsubscribes from `postMessage` events. Always call before unmounting the host component to avoid leaks.
+Отписывается от событий `postMessage`. Всегда вызывайте перед размонтированием хост-компонента, чтобы избежать утечек.
 
 ### `installFinish` {#installfinish}
 
@@ -136,7 +136,7 @@ Unsubscribes from `postMessage` events. Always call before unmounting the host c
 installFinish(): Promise<any>
 ```
 
-Sends `setInstallFinish` to the parent. Throws `Error('Application was previously installed. You cannot call installFinish')`{lang="ts-type"} when called outside install mode — guard with `isInstallMode`.
+Отправляет `setInstallFinish` родителю. Выбрасывает `Error('Application was previously installed. You cannot call installFinish')`{lang="ts-type"} при вызове вне режима установки — защищайтесь проверкой `isInstallMode`.
 
 ### `getAppSid` {#getappsid}
 
@@ -144,7 +144,7 @@ Sends `setInstallFinish` to the parent. Throws `Error('Application was previousl
 getAppSid(): string
 ```
 
-Application session id relative to the parent window (mirrors `APP_SID`).
+Идентификатор сессии приложения относительно родительского окна (повторяет `APP_SID`).
 
 ### `getLang` {#getlang}
 
@@ -152,7 +152,7 @@ Application session id relative to the parent window (mirrors `APP_SID`).
 getLang(): B24LangList
 ```
 
-Bitrix24 interface language enum. See [LangList](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/language/list.ts).
+Enum языка интерфейса Bitrix24. См. [LangList](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/language/list.ts).
 
 ### `getTargetOrigin` / `getTargetOriginWithPath` {#gettargetorigin-gettargetoriginwithpath}
 
@@ -161,16 +161,16 @@ getTargetOrigin(): string
 getTargetOriginWithPath(): Map<ApiVersion, string>
 ```
 
-Portal origin and per-version REST endpoints (parent-supplied).
+Origin портала и REST-endpoint-ы для каждой версии (предоставляются родителем).
 
-### Inherited from `AbstractB24` {#inherited-from-abstractb24}
+### Унаследовано от `AbstractB24` {#inherited-from-abstractb24}
 
-`getHttpClient`, `setHttpClient`, `setRestrictionManagerParams`, `getLogger`, `setLogger`, `actions`, `tools`. See:
+`getHttpClient`, `setHttpClient`, `setRestrictionManagerParams`, `getLogger`, `setLogger`, `actions`, `tools`. См.:
 
-- [Limiters](/docs/working-with-the-rest-api/limiters/)
-- [Logger](/docs/working-with-the-rest-api/logger/)
+- [Лимитеры](/docs/working-with-the-rest-api/limiters/)
+- [Логгер](/docs/working-with-the-rest-api/logger/)
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import {
@@ -224,5 +224,5 @@ bootstrap()
 ```
 
 ::note
-The page must run as a [Bitrix24 application](https://apidocs.bitrix24.ru/api-reference/app-installation/local-apps/index.html) (inside a placement iframe). Outside that context the parent-window handshake never resolves.
+Страница должна работать как [приложение Bitrix24](https://apidocs.bitrix24.ru/api-reference/app-installation/local-apps/index.html) (внутри placement-iframe). Вне этого контекста рукопожатие с родительским окном никогда не завершится.
 ::

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-auth.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-auth.md
@@ -1,9 +1,9 @@
 ---
-title: Auth Manager Class
-description: 'Designed for managing authentication in Bitrix24 applications. It handles authentication data received from the parent window and provides methods for updating and retrieving this data.'
+title: Класс AuthManager
+description: 'Предназначен для управления аутентификацией в приложениях Bitrix24. Обрабатывает данные аутентификации, полученные от родительского окна, и предоставляет методы для их обновления и получения.'
 category: 'B24Frame'
 audited: 2026-05-29
-navigation.title: Auth
+navigation.title: Авторизация
 links:
   - label: AuthManager
     iconName: GitHubIcon
@@ -14,7 +14,7 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
 ```ts
@@ -25,18 +25,18 @@ if ($b24.auth.isAdmin) {
 }
 ```
 
-## Getters {#getters}
+## Геттеры {#getters}
 ### isAdmin {#isadmin}
 ```ts-type
 get isAdmin(): boolean
 ```
 
-Returns `true` if the current user has admin rights, otherwise `false`.
+Возвращает `true`, если у текущего пользователя есть права администратора, иначе `false`.
 
-## Methods {#methods}
+## Методы {#methods}
 
-::callout{color="air-secondary" iconName="GitHubIcon" title="AuthActions interface" to="https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts"}
-Implements the `AuthActions` interface.
+::callout{color="air-secondary" iconName="GitHubIcon" title="Интерфейс AuthActions" to="https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts"}
+Реализует интерфейс `AuthActions`.
 ::
 
 ### getAuthData {#getauthdata}
@@ -44,20 +44,20 @@ Implements the `AuthActions` interface.
 getAuthData(): false | AuthData
 ```
 
-Returns authentication data [`AuthData`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts) if it has not expired. If expired, returns `false`.
+Возвращает данные аутентификации [`AuthData`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts), если они не истекли. Если истекли — возвращает `false`.
 
 ### refreshAuth {#refreshauth}
 ```ts-type
 async refreshAuth(): Promise<AuthData>
 ```
 
-Refreshes authentication data through the parent window and returns the updated data [`AuthData`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts).
+Обновляет данные аутентификации через родительское окно и возвращает обновлённые данные [`AuthData`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts).
 
 ### getUniq {#getuniq}
 ```ts-type
 getUniq(prefix: string): string
 ```
 
-Returns a unique string consisting of the given prefix and `AuthData.memberId`{lang="ts-type"}.
+Возвращает уникальную строку, состоящую из заданного префикса и `AuthData.memberId`{lang="ts-type"}.
 
-> Used in `B24PullClientManager`{lang="ts-type"}
+> Используется в `B24PullClientManager`{lang="ts-type"}

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
@@ -1,9 +1,9 @@
 ---
-title: Dialog Manager Class
-description: 'Wraps the BX24 system dialogs (user picker, access permission picker, CRM entity picker) so they can be opened from inside a Bitrix24 application iframe.'
+title: Класс DialogManager
+description: 'Оборачивает системные диалоги BX24 (выбор пользователя, выбор прав доступа, выбор CRM-сущности), чтобы их можно было открывать изнутри iframe приложения Bitrix24.'
 category: 'B24Frame'
 audited: 2026-05-29
-navigation.title: Dialog
+navigation.title: Диалог
 links:
   - label: DialogManager
     iconName: GitHubIcon
@@ -13,11 +13,11 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-frame-ui/SKILL.md
 ---
 
-`DialogManager` is exposed via [`$b24.dialog`](/docs/working-with-the-rest-api/frame/#dialog) on a `B24Frame` instance and is only available when your application is rendered inside a Bitrix24 iframe (it relies on `postMessage` to talk to the parent window).
+`DialogManager` доступен через [`$b24.dialog`](/docs/working-with-the-rest-api/frame/#dialog) на экземпляре `B24Frame` и доступен только когда ваше приложение отрисовано внутри iframe Bitrix24 (он использует `postMessage` для общения с родительским окном).
 
-It mirrors the legacy [`BX24.selectUser`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-user.html), [`BX24.selectUsers`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-users.html), [`BX24.selectAccess`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-access.html) and [`BX24.selectCRM`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-crm.html) helpers, but returns strongly-typed `Promise`s instead of taking callbacks.
+Он повторяет legacy-хелперы [`BX24.selectUser`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-user.html), [`BX24.selectUsers`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-users.html), [`BX24.selectAccess`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-access.html) и [`BX24.selectCRM`](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-dialogues/bx24-select-crm.html), но возвращает строго типизированные `Promise` вместо приёма callback-ов.
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### selectUser {#selectuser}
 
@@ -25,9 +25,9 @@ It mirrors the legacy [`BX24.selectUser`](https://apidocs.bitrix24.ru/sdk/bx24-j
 async selectUser(): Promise<null|SelectedUser>
 ```
 
-Displays the standard dialog for selecting a single company employee.
+Отображает стандартный диалог выбора одного сотрудника компании.
 
-The promise resolves to a [`SelectedUser`](#selecteduser) object, or `null` if the user closed the dialog without making a selection.
+Promise разрешается объектом [`SelectedUser`](#selecteduser) или `null`, если пользователь закрыл диалог, не сделав выбор.
 
 ```ts
 // ... /////
@@ -48,9 +48,9 @@ const makeSelectUser = async() => {
 async selectUsers(): Promise<SelectedUser[]>
 ```
 
-Displays the standard dialog for selecting multiple company employees.
+Отображает стандартный диалог выбора нескольких сотрудников компании.
 
-The promise resolves to an array of [`SelectedUser`](#selecteduser) objects. The array is empty when the user confirms the dialog without picking anyone.
+Promise разрешается массивом объектов [`SelectedUser`](#selecteduser). Массив пуст, если пользователь подтвердил диалог, никого не выбрав.
 
 ```ts
 import { SelectedUser } from '@bitrix24/b24jssdk'
@@ -75,13 +75,13 @@ const makeSelectUsers = async() => {
 async selectAccess(blockedAccessPermissions?: string[]): Promise<SelectedAccess[]>
 ```
 
-Displays the standard access permission selection dialog (departments, groups, individual users, and predefined permission codes such as `AU` or `CR`).
+Отображает стандартный диалог выбора прав доступа (отделы, группы, отдельные пользователи и предопределённые коды прав, такие как `AU` или `CR`).
 
-| Parameter                   | Type       | Description                                                                                                                                |
-|-----------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `blockedAccessPermissions`  | `string[]` | Optional list of permission codes to disable in the dialog. Defaults to `[]`. Useful when some permissions are already granted elsewhere. |
+| Параметр                    | Тип        | Описание                                                                                                                                  |
+|-----------------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `blockedAccessPermissions`  | `string[]` | Необязательный список кодов прав, которые нужно отключить в диалоге. По умолчанию `[]`. Полезно, когда некоторые права уже выданы в другом месте. |
 
-The promise resolves to an array of [`SelectedAccess`](#selectedaccess) entries.
+Promise разрешается массивом записей [`SelectedAccess`](#selectedaccess).
 
 ```ts
 // ... /////
@@ -102,18 +102,18 @@ const makeSelectAccess = async() => {
 async selectCRM(params?: SelectCRMParams): Promise<SelectedCRM>
 ```
 
-Displays the standard dialog for selecting CRM entities (leads, contacts, companies, deals, quotes).
+Отображает стандартный диалог выбора CRM-сущностей (лиды, контакты, компании, сделки, предложения).
 
-| Parameter                  | Type                            | Description                                                                                                                                                                  |
-|----------------------------|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `params.entityType`        | `SelectCRMParamsEntityType[]`   | Which entity types to show as tabs in the picker. Allowed values: `lead`, `contact`, `company`, `deal`, `quote`.                                                             |
-| `params.multiple`          | `boolean`                       | Allow multiple selection. Defaults to `false`.                                                                                                                                |
-| `params.value`             | `SelectCRMParamsValue`          | Optional map of entity IDs to mark as initially selected. Applied **only when `multiple` is `true`** — single-select mode ignores it.                                          |
+| Параметр                   | Тип                             | Описание                                                                                                                                                                     |
+|----------------------------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `params.entityType`        | `SelectCRMParamsEntityType[]`   | Какие типы сущностей показывать вкладками в окне выбора. Допустимые значения: `lead`, `contact`, `company`, `deal`, `quote`.                                                  |
+| `params.multiple`          | `boolean`                       | Разрешить множественный выбор. По умолчанию `false`.                                                                                                                          |
+| `params.value`             | `SelectCRMParamsValue`          | Необязательная карта идентификаторов сущностей, которые нужно отметить как изначально выбранные. Применяется **только когда `multiple` равно `true`** — режим одиночного выбора её игнорирует. |
 
-The promise resolves to a [`SelectedCRM`](#selectedcrm) object whose properties (`lead`, `contact`, `company`, `deal`, `quote`) are real JavaScript arrays of [`SelectedCRMEntity`](#selectedcrmentity). Buckets for entity types the user did not pick (or did not request) are left `undefined` rather than set to an empty array.
+Promise разрешается объектом [`SelectedCRM`](#selectedcrm), свойства которого (`lead`, `contact`, `company`, `deal`, `quote`) — настоящие JavaScript-массивы [`SelectedCRMEntity`](#selectedcrmentity). Корзины для типов сущностей, которые пользователь не выбрал (или не запрашивал), остаются `undefined`, а не пустым массивом.
 
 ::note
-Since v1.0.7, `selectCRM` always returns real arrays. Earlier versions forwarded the parent window's payload as-is, so each bucket was actually a `Record<string, SelectedCRMEntity>` (e.g. `{ 0: {...}, 1: {...} }`) — calling `.length` or `.map()` on it returned `undefined`. Code written against the documented types continues to work; the only behavioural difference is that the runtime shape now matches the types.
+Начиная с v1.0.7, `selectCRM` всегда возвращает настоящие массивы. Более ранние версии передавали payload родительского окна как есть, поэтому каждая корзина фактически была `Record<string, SelectedCRMEntity>` (например, `{ 0: {...}, 1: {...} }`) — вызов `.length` или `.map()` на ней возвращал `undefined`. Код, написанный по документированным типам, продолжает работать; единственное поведенческое различие в том, что теперь runtime-форма совпадает с типами.
 ::
 
 ```ts
@@ -141,46 +141,46 @@ const makeSelectCRM = async() => {
 ```
 
 ::note
-Single-select mode (`multiple: false`) still resolves to the same `SelectedCRM` shape — buckets just contain at most one element. To grab that element use `selected.contact?.[0]`.
+Режим одиночного выбора (`multiple: false`) всё равно разрешается той же формой `SelectedCRM` — корзины просто содержат не более одного элемента. Чтобы получить этот элемент, используйте `selected.contact?.[0]`.
 ::
 
-## Data Types {#data-types}
+## Типы данных {#data-types}
 
 ### SelectedUser {#selecteduser}
 
-Represents a single company employee picked through `selectUser` / `selectUsers`. The `sub` and `sup` flags describe the hierarchical relationship with the current user.
+Представляет одного сотрудника компании, выбранного через `selectUser` / `selectUsers`. Флаги `sub` и `sup` описывают иерархические отношения с текущим пользователем.
 
-| Field      | Type           | Description                                                                                |
+| Поле       | Тип            | Описание                                                                                   |
 |------------|----------------|--------------------------------------------------------------------------------------------|
-| `id`       | `NumberString` | User identifier — a string containing a numeric value (e.g. `"42"`).                       |
-| `name`     | `string`       | Formatted display name.                                                                    |
-| `photo`    | `string`       | URL of the user's avatar.                                                                  |
-| `position` | `string`       | User's job title.                                                                          |
-| `url`      | `string`       | URL of the user's profile inside the portal.                                               |
-| `sub`      | `boolean`      | `true` when the selected user is a subordinate of the current user.                        |
-| `sup`      | `boolean`      | `true` when the selected user is a supervisor of the current user.                         |
+| `id`       | `NumberString` | Идентификатор пользователя — строка с числовым значением (например, `"42"`).               |
+| `name`     | `string`       | Отформатированное отображаемое имя.                                                         |
+| `photo`    | `string`       | URL аватара пользователя.                                                                   |
+| `position` | `string`       | Должность пользователя.                                                                     |
+| `url`      | `string`       | URL профиля пользователя внутри портала.                                                    |
+| `sub`      | `boolean`      | `true`, если выбранный пользователь — подчинённый текущего пользователя.                    |
+| `sup`      | `boolean`      | `true`, если выбранный пользователь — руководитель текущего пользователя.                   |
 
 ### SelectedAccess {#selectedaccess}
 
-Represents one entry returned by `selectAccess`.
+Представляет одну запись, возвращаемую `selectAccess`.
 
-| Field  | Type     | Description                                                                                              |
-|--------|----------|----------------------------------------------------------------------------------------------------------|
-| `id`   | `string` | Permission code (see the table below).                                                                   |
-| `name` | `string` | Human-readable name of the permission, localized to the portal language.                                 |
+| Поле   | Тип      | Описание                                                                                                 |
+|--------|----------|---------------------------------------------------------------------------------------------------------|
+| `id`   | `string` | Код права (см. таблицу ниже).                                                                            |
+| `name` | `string` | Человекочитаемое имя права, локализованное под язык портала.                                             |
 
-The `id` field uses Bitrix24's permission-code grammar:
+Поле `id` использует грамматику кодов прав Bitrix24:
 
-| Pattern        | Meaning                                                       |
+| Шаблон         | Значение                                                      |
 |----------------|---------------------------------------------------------------|
-| `AU`           | All authorized portal users.                                  |
-| `CR`           | Current user.                                                 |
-| `U${number}`   | A specific user by ID.                                        |
-| `IU${number}`  | An employee by ID (extranet-aware).                           |
-| `D${number}`   | All employees of a department.                                |
-| `DR${number}`  | All employees of a department, including subdepartments.      |
-| `G${number}`   | A user group (e.g. `G2` — all visitors).                      |
-| `SG${number}`  | A social network / workgroup.                                 |
+| `AU`           | Все авторизованные пользователи портала.                      |
+| `CR`           | Текущий пользователь.                                         |
+| `U${number}`   | Конкретный пользователь по ID.                                |
+| `IU${number}`  | Сотрудник по ID (с учётом экстранета).                        |
+| `D${number}`   | Все сотрудники отдела.                                        |
+| `DR${number}`  | Все сотрудники отдела, включая подотделы.                     |
+| `G${number}`   | Группа пользователей (например, `G2` — все посетители).       |
+| `SG${number}`  | Соцсеть / рабочая группа.                                     |
 
 ### SelectCRMParamsEntityType {#selectcrmparamsentitytype}
 
@@ -188,41 +188,41 @@ The `id` field uses Bitrix24's permission-code grammar:
 type SelectCRMParamsEntityType = 'lead' | 'contact' | 'company' | 'deal' | 'quote'
 ```
 
-The set of CRM entity kinds that `selectCRM` understands. Passed in as `params.entityType` and used as the keys of both `SelectCRMParamsValue` and `SelectedCRM`.
+Набор видов CRM-сущностей, которые понимает `selectCRM`. Передаётся как `params.entityType` и используется в качестве ключей `SelectCRMParamsValue` и `SelectedCRM`.
 
 ### SelectCRMParamsValue {#selectcrmparamsvalue}
 
-Map of entity IDs to pre-select when `multiple: true`. Only the requested entity types are read; extra keys are ignored.
+Карта идентификаторов сущностей для предварительного выбора при `multiple: true`. Читаются только запрошенные типы сущностей; лишние ключи игнорируются.
 
-| Field      | Type       | Description                                            |
+| Поле       | Тип        | Описание                                               |
 |------------|------------|--------------------------------------------------------|
-| `lead`     | `number[]` | Lead IDs to mark as already selected.                  |
-| `contact`  | `number[]` | Contact IDs to mark as already selected.               |
-| `company`  | `number[]` | Company IDs to mark as already selected.               |
-| `deal`     | `number[]` | Deal IDs to mark as already selected.                  |
-| `quote`    | `number[]` | Quote IDs to mark as already selected.                 |
+| `lead`     | `number[]` | ID лидов, которые нужно отметить как уже выбранные.     |
+| `contact`  | `number[]` | ID контактов, которые нужно отметить как уже выбранные. |
+| `company`  | `number[]` | ID компаний, которые нужно отметить как уже выбранные.  |
+| `deal`     | `number[]` | ID сделок, которые нужно отметить как уже выбранные.    |
+| `quote`    | `number[]` | ID предложений, которые нужно отметить как уже выбранные. |
 
 ### SelectedCRMEntity {#selectedcrmentity}
 
-Represents one row inside a `SelectedCRM` bucket.
+Представляет одну строку внутри корзины `SelectedCRM`.
 
-| Field   | Type                          | Description                                                                                                |
-|---------|-------------------------------|------------------------------------------------------------------------------------------------------------|
-| `id`    | `string`                      | Prefixed entity identifier — see the table in [`SelectedCRM`](#selectedcrm).                               |
-| `type`  | `SelectCRMParamsEntityType`   | Entity kind (`lead` / `contact` / `company` / `deal` / `quote`).                                           |
-| `place` | `string`                      | UI placement label used by Bitrix24 (rarely needed; informational).                                        |
-| `title` | `string`                      | Display title of the entity (e.g. company name, deal title, contact full name).                            |
-| `desc`  | `string`                      | Short description shown next to the title in the picker.                                                   |
-| `url`   | `string`                      | URL to open the entity inside the portal.                                                                  |
+| Поле    | Тип                           | Описание                                                                                                  |
+|---------|-------------------------------|----------------------------------------------------------------------------------------------------------|
+| `id`    | `string`                      | Идентификатор сущности с префиксом — см. таблицу в [`SelectedCRM`](#selectedcrm).                         |
+| `type`  | `SelectCRMParamsEntityType`   | Вид сущности (`lead` / `contact` / `company` / `deal` / `quote`).                                         |
+| `place` | `string`                      | Метка placement в UI, используемая Bitrix24 (нужна редко; информационная).                                |
+| `title` | `string`                      | Отображаемый заголовок сущности (например, название компании, заголовок сделки, полное имя контакта).     |
+| `desc`  | `string`                      | Краткое описание, показываемое рядом с заголовком в окне выбора.                                          |
+| `url`   | `string`                      | URL для открытия сущности внутри портала.                                                                 |
 
 ### SelectedCRM {#selectedcrm}
 
-Result of `selectCRM`. Each property is either an array of [`SelectedCRMEntity`](#selectedcrmentity) refined with a literal `id` pattern, or `undefined` when the user picked nothing of that type.
+Результат `selectCRM`. Каждое свойство — это либо массив [`SelectedCRMEntity`](#selectedcrmentity), уточнённый литеральным шаблоном `id`, либо `undefined`, если пользователь не выбрал ничего этого типа.
 
-| Field      | Type                                                                  | Description                                                                                              |
-|------------|-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| `lead`     | `(SelectedCRMEntity & { id: ``L_${number}`` })[]`                     | Picked leads. Each `id` looks like `L_42`.                                                               |
-| `contact`  | `(SelectedCRMEntity & { id: ``C_${number}``, image: string })[]`      | Picked contacts. The extra `image` field holds the contact's avatar URL.                                 |
-| `company`  | `(SelectedCRMEntity & { id: ``CO_${number}``, image: string })[]`     | Picked companies. The extra `image` field holds the company logo URL.                                    |
-| `deal`     | `(SelectedCRMEntity & { id: ``D_${number}`` })[]`                     | Picked deals. Each `id` looks like `D_17`.                                                               |
-| `quote`    | `(SelectedCRMEntity & { id: ``Q_${number}`` })[]`                     | Picked quotes. Each `id` looks like `Q_3`.                                                               |
+| Поле       | Тип                                                                   | Описание                                                                                                |
+|------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `lead`     | `(SelectedCRMEntity & { id: ``L_${number}`` })[]`                     | Выбранные лиды. Каждый `id` выглядит как `L_42`.                                                         |
+| `contact`  | `(SelectedCRMEntity & { id: ``C_${number}``, image: string })[]`      | Выбранные контакты. Дополнительное поле `image` содержит URL аватара контакта.                           |
+| `company`  | `(SelectedCRMEntity & { id: ``CO_${number}``, image: string })[]`     | Выбранные компании. Дополнительное поле `image` содержит URL логотипа компании.                          |
+| `deal`     | `(SelectedCRMEntity & { id: ``D_${number}`` })[]`                     | Выбранные сделки. Каждый `id` выглядит как `D_17`.                                                       |
+| `quote`    | `(SelectedCRMEntity & { id: ``Q_${number}`` })[]`                     | Выбранные предложения. Каждый `id` выглядит как `Q_3`.                                                   |

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-options.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-options.md
@@ -1,9 +1,9 @@
 ---
-title: Options Manager Class
-description: 'Used for managing application and user settings in the Bitrix24 application. It allows initializing data, getting, and setting options through messages to the parent window.'
+title: Класс OptionsManager
+description: 'Используется для управления настройками приложения и пользователя в приложении Bitrix24. Позволяет инициализировать данные, получать и устанавливать опции через сообщения родительскому окну.'
 category: 'B24Frame'
 audited: 2026-05-29
-navigation.title: Options
+navigation.title: Опции
 links:
   - label: OptionsManager
     iconName: GitHubIcon
@@ -14,19 +14,19 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### appGet {#appget}
 ```ts-type
 appGet(option: string): any
 ```
 
-Retrieves the value of an application option.
+Получает значение опции приложения.
 
-Returns the option value or throws an error if the option is not set.
+Возвращает значение опции или выбрасывает ошибку, если опция не задана.
 
 ```ts
 // ... /////
@@ -40,7 +40,7 @@ const value: any = $b24.options.appGet('test')
 async appSet(option: string, value: any): Promise<void>
 ```
 
-Sets the value of an application option.
+Устанавливает значение опции приложения.
 
 ```ts
 // ... /////
@@ -54,9 +54,9 @@ await $b24.options.appSet('test', 123)
 userGet(option: string): any
 ```
 
-Retrieves the value of a user option.
+Получает значение пользовательской опции.
 
-Returns the option value or throws an error if the option is not set.
+Возвращает значение опции или выбрасывает ошибку, если опция не задана.
 
 ```ts
 // ... /////
@@ -70,7 +70,7 @@ const value: any = $b24.options.userGet('test')
 async userSet(option: string, value: any): Promise<void>
 ```
 
-Sets the value of a user option.
+Устанавливает значение пользовательской опции.
 
 ```ts
 // ... /////

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
@@ -1,9 +1,9 @@
 ---
-title: Parent Manager Class
-description: 'Provides methods for managing the parent application window in Bitrix24, including resizing the window, managing scroll, initiating calls, and opening the messenger.'
+title: Класс ParentManager
+description: 'Предоставляет методы для управления родительским окном приложения в Bitrix24, включая изменение размера окна, управление прокруткой, инициацию звонков и открытие мессенджера.'
 category: 'B24Frame'
 audited: 2026-05-29
-navigation.title: Parent
+navigation.title: Родительское окно
 links:
   - label: ParentManager
     iconName: GitHubIcon
@@ -14,7 +14,7 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
 ```ts
@@ -24,28 +24,28 @@ $b24 = await initializeB24Frame()
 await $b24.parent.fitWindow()
 ```
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### closeApplication {#closeapplication}
 ```ts-type
 async closeApplication(): Promise<void>
 ```
 
-Closes the application slider.
+Закрывает слайдер приложения.
 
 ### fitWindow {#fitwindow}
 ```ts-type
 async fitWindow(): Promise<any>
 ```
 
-Sets the application frame size according to its content size.
+Устанавливает размер фрейма приложения в соответствии с размером его содержимого.
 
 ### resizeWindow {#resizewindow}
 ```ts-type
 async resizeWindow(width: number, height: number): Promise<void>
 ```
 
-Resizes the application frame to the specified width and height.
+Изменяет размер фрейма приложения до указанных ширины и высоты.
 
 ### resizeWindowAuto {#resizewindowauto}
 ```ts-type
@@ -56,90 +56,90 @@ async resizeWindowAuto(
 ): Promise<void>
 ```
 
-Automatically resizes the `document.body` of the application frame according to its content size.
+Автоматически изменяет размер `document.body` фрейма приложения в соответствии с размером его содержимого.
 
-| Parameter | Type | Description |
+| Параметр | Тип | Описание |
 |----|----|----|
-| `appNode` | `null\|HTMLElement` | Application node for height calculation. |
-| `minHeight` | `number` | Minimum height. |
-| `minWidth` | `number` | Minimum width. |
+| `appNode` | `null\|HTMLElement` | Узел приложения для расчёта высоты. |
+| `minHeight` | `number` | Минимальная высота. |
+| `minWidth` | `number` | Минимальная ширина. |
 
 ### getScrollSize {#getscrollsize}
 ```ts-type
 getScrollSize(): { scrollWidth: number, scrollHeight: number }
 ```
 
-Returns the internal dimensions of the application frame.
+Возвращает внутренние размеры фрейма приложения.
 
 ### scrollParentWindow {#scrollparentwindow}
 ```ts-type
 async scrollParentWindow(scroll: number): Promise<void>
 ```
 
-Scrolls the parent window to the specified position.
+Прокручивает родительское окно до указанной позиции.
 
 ### reloadWindow {#reloadwindow}
 ```ts-type
 async reloadWindow(): Promise<void>
 ```
 
-Reloads the application page.
+Перезагружает страницу приложения.
 
 ### setTitle {#settitle}
 ```ts-type
 async setTitle(title: string): Promise<void>
 ```
 
-Sets the page title.
+Устанавливает заголовок страницы.
 
 ### imCallTo {#imcallto}
 ```ts-type
 async imCallTo(userId: number, isVideo: boolean = true): Promise<void>
 ```
 
-Initiates a call through internal communication.
+Инициирует звонок через внутреннюю связь.
 
-| Parameter | Type      | Description                                         |
+| Параметр  | Тип       | Описание                                            |
 |-----------|-----------|-----------------------------------------------------|
-| `userId`  | `number`  | User identifier.                                    |
-| `isVideo` | `boolean` | `true` for video call, `false` for audio call.      |
+| `userId`  | `number`  | Идентификатор пользователя.                         |
+| `isVideo` | `boolean` | `true` — видеозвонок, `false` — аудиозвонок.        |
 
 ### imPhoneTo {#imphoneto}
 ```ts-type
 async imPhoneTo(phone: string): Promise<void>
 ```
 
-Makes a call to the specified phone number.
+Совершает звонок на указанный номер телефона.
 
-| Parameter | Type      | Description        |
+| Параметр  | Тип       | Описание           |
 |-----------|-----------|--------------------|
-| `phone`   | `string`  | Phone number.      |
+| `phone`   | `string`  | Номер телефона.    |
 
 ### imOpenMessenger {#imopenmessenger}
 ```ts-type
 async imOpenMessenger(dialogId: number|'chat${number}'|'sg${number}'|'imol|${number}'|undefined): Promise<void>
 ```
 
-Opens the messenger window.
+Открывает окно мессенджера.
 
-| Parameter  | Type                                                              | Description            |
+| Параметр   | Тип                                                              | Описание               |
 |------------|-------------------------------------------------------------------|------------------------|
-| `dialogId` | `number\|chat${number}\|sg${number}\|imol\|${number}\|undefined`  | Dialog identifier.     |
+| `dialogId` | `number\|chat${number}\|sg${number}\|imol\|${number}\|undefined`  | Идентификатор диалога. |
 
 ### imOpenHistory {#imopenhistory}
 ```ts-type
 async imOpenHistory(dialogId: number|'chat${number}'|'imol|${number}'): Promise<void>
 ```
 
-Opens the message history window.
+Открывает окно истории сообщений.
 
-| Parameter  | Type                                      | Description            |
+| Параметр   | Тип                                       | Описание               |
 |------------|-------------------------------------------|------------------------|
-| `dialogId` | `number\|chat${number}\|imol\|${number}`  | Dialog identifier.     |
+| `dialogId` | `number\|chat${number}\|imol\|${number}`  | Идентификатор диалога. |
 
-## Examples {#examples}
+## Примеры {#examples}
 
-### Try call {#try-call}
+### Пробный звонок {#try-call}
 
 ::code-example
 ---

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
@@ -1,6 +1,6 @@
 ---
-title: Placement Manager Class
-description: 'Used for managing the placement of widgets in the Bitrix24 application.'
+title: Класс PlacementManager
+description: 'Используется для управления placement виджетов в приложении Bitrix24.'
 category: 'B24Frame'
 audited: 2026-05-29
 navigation.title: Placement
@@ -14,42 +14,42 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-[Learn more](https://apidocs.bitrix24.ru/api-reference/widgets/ui-interaction/index.html)
+[Подробнее](https://apidocs.bitrix24.ru/api-reference/widgets/ui-interaction/index.html)
 
-## Getters {#getters}
+## Геттеры {#getters}
 
 ### title {#title}
 ```ts-type
 get title(): string
 ```
-Alias of [`placement`](#placement). Returns the placement title (`'DEFAULT'` when no title was provided by the parent window).
+Псевдоним [`placement`](#placement). Возвращает заголовок placement (`'DEFAULT'`, если заголовок не был предоставлен родительским окном).
 
 ### `placement` {#placement}
 ```ts-type
 get placement(): string
 ```
-Returns the placement title. By default, returns `'DEFAULT'` if the title is not set.
+Возвращает заголовок placement. По умолчанию возвращает `'DEFAULT'`, если заголовок не задан.
 
 ### isDefault {#isdefault}
 ```ts-type
 get isDefault(): boolean
 ```
-Returns `true` if the placement title is `'DEFAULT'`.
+Возвращает `true`, если заголовок placement равен `'DEFAULT'`.
 
 ### options {#options}
 ```ts-type
 get options(): any
 ```
-Returns the placement options object. The object is frozen to prevent modifications.
+Возвращает объект опций placement. Объект заморожен для предотвращения изменений.
 
 ### isSliderMode {#isslidermode}
 ```ts-type
 get isSliderMode(): boolean
 ```
-Returns `true` if the widget is operating in slider mode (option `IFRAME` is `'Y'`).
+Возвращает `true`, если виджет работает в режиме слайдера (опция `IFRAME` равна `'Y'`).
 
 ```ts
 // ... /////
@@ -60,14 +60,14 @@ if ($b24.placement.isSliderMode) {
 }
 ```
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### getInterface {#getinterface}
 ```ts-type
 async getInterface(): Promise<any>
 ```
 
-Getting information about the JS interface of the current embedding location: a list of possible commands and events.
+Получение информации о JS-интерфейсе текущего места встраивания: список возможных команд и событий.
 
 ```ts
 // ... /////
@@ -81,7 +81,7 @@ const value: any = await $b24.placement.getInterface()
 async bindEvent(eventName: string): Promise<any>
 ```
 
-Setting up the event handler for the interface
+Настройка обработчика события для интерфейса.
 
 ### call {#call}
 ```ts-type
@@ -89,7 +89,7 @@ async call(command: 'setValue', parameters: { value: string }): Promise<any>
 async call(command: string, parameters?: Record<string, any>): Promise<any>
 ```
 
-Call the registered interface command.
+Вызывает зарегистрированную команду интерфейса.
 
 ```ts
 import { LoggerFactory } from '@bitrix24/b24jssdk'
@@ -105,20 +105,20 @@ $b24.placement.call('reloadData')
 ```
 
 ::warning
-The `setValue` command is special: the parent window calls `JSON.parse(value)`
-on the received payload, so `value` **must** be a JSON-serialized string. Passing
-a raw string or an object directly will fail (`SyntaxError` from
-`JSON.parse`, or silent corruption to `"[object Object]"`).
+Команда `setValue` особенная: родительское окно вызывает `JSON.parse(value)`
+на полученном payload, поэтому `value` **обязан** быть JSON-сериализованной строкой. Передача
+обычной строки или объекта напрямую приведёт к ошибке (`SyntaxError` из
+`JSON.parse` или тихому повреждению до `"[object Object]"`).
 
-Prefer the [`setValue`](#setvalue) helper, which serializes for you. If you use
-`call('setValue', ...)` directly, the SDK will throw a `TypeError` when `value`
-is not a string.
+Предпочитайте хелпер [`setValue`](#setvalue), который сериализует за вас. Если вы используете
+`call('setValue', ...)` напрямую, SDK выбросит `TypeError`, когда `value`
+не является строкой.
 
 ```ts
-// ✗ throws TypeError — value is not a string
+// ✗ выбрасывает TypeError — value не является строкой
 await $b24.placement.call('setValue', { value: 'test' })
 
-// ✓ works — value is a JSON string
+// ✓ работает — value является JSON-строкой
 await $b24.placement.call('setValue', { value: JSON.stringify('test') })
 await $b24.placement.call('setValue', { value: JSON.stringify({ id: 1 }) })
 ```
@@ -129,9 +129,9 @@ await $b24.placement.call('setValue', { value: JSON.stringify({ id: 1 }) })
 async setValue(value: unknown): Promise<any>
 ```
 
-Convenience wrapper around `placement.call('setValue', ...)` that performs
-`JSON.stringify` on the value for you. Accepts any JSON-serializable value
-(string, number, boolean, object, array).
+Удобная обёртка над `placement.call('setValue', ...)`, которая выполняет
+`JSON.stringify` над значением за вас. Принимает любое JSON-сериализуемое значение
+(строку, число, булево, объект, массив).
 
 ```ts
 $b24 = await initializeB24Frame()
@@ -149,13 +149,13 @@ async callCustomBind(
 ): Promise<any>
 ```
 
-Calls an interface command and registers a callback that receives subsequent events from the command. Use this for commands that emit ongoing events (e.g. progress updates) instead of resolving once.
+Вызывает команду интерфейса и регистрирует callback, который получает последующие события от команды. Используйте это для команд, которые порождают непрерывные события (например, обновления прогресса), вместо однократного разрешения.
 
-`parameters` accepts three shapes:
+`parameters` принимает три формы:
 
-- `null` — no payload.
-- `string` — sent as `singleOption`.
-- `Record<string, any>` — spread into the message payload.
+- `null` — без payload.
+- `string` — отправляется как `singleOption`.
+- `Record<string, any>` — раскрывается в payload сообщения.
 
 ```ts
 $b24 = await initializeB24Frame()

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
@@ -1,9 +1,9 @@
 ---
-title: Slider Manager Class
-description: 'Provides methods for working with sliders in the Bitrix24 application. It allows opening and closing sliders, as well as managing their content.'
+title: Класс SliderManager
+description: 'Предоставляет методы для работы со слайдерами в приложении Bitrix24. Позволяет открывать и закрывать слайдеры, а также управлять их содержимым.'
 category: 'B24Frame'
 audited: 2026-05-29
-navigation.title: Slider
+navigation.title: Слайдер
 links:
   - label: SliderManager
     iconName: GitHubIcon
@@ -17,10 +17,10 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### openSliderAppPage {#opensliderapppage}
 
@@ -28,13 +28,13 @@ We are still updating this page. Some data may be missing here — we will compl
 async openSliderAppPage(params: any = {}}: Promise<any>
 ```
 
-The `openSliderAppPage`{lang="ts-type"} method allows you to open the current app in a new slider, passing arbitrary parameters.
+Метод `openSliderAppPage`{lang="ts-type"} позволяет открыть текущее приложение в новом слайдере, передав произвольные параметры.
 
-How it works:
+Как это работает:
 
-* **Data Passing:** You call the method and pass an object with parameters (e.g., place, action, or id).
-* **Processing in the Application:** On the application side, it's most convenient to intercept these parameters through middleware. This allows you to decide which route to display to the user before the page is rendered.
-* **Seamless Navigation:** The user sees a new slider with the desired content, while the redirection logic is hidden within the application.
+* **Передача данных:** вы вызываете метод и передаёте объект с параметрами (например, place, action или id).
+* **Обработка в приложении:** на стороне приложения удобнее всего перехватывать эти параметры через middleware. Это позволяет решить, какой маршрут показать пользователю до отрисовки страницы.
+* **Бесшовная навигация:** пользователь видит новый слайдер с нужным содержимым, а логика перенаправления скрыта внутри приложения.
 
 ::code-example
 ---
@@ -51,7 +51,7 @@ b24FrameOnly: true
 async closeSliderAppPage(): Promise<void>
 ```
 
-Closes the slider with the application.
+Закрывает слайдер с приложением.
 
 ::code-example
 ---
@@ -68,28 +68,28 @@ b24FrameOnly: true
 async openPath(url: URL, width: number = 1640): Promise<StatusClose>
 ```
 
-Opens the specified path inside the portal in a slider.
+Открывает указанный путь внутри портала в слайдере.
 
-Handles errors related to mobile device usage and can open the URL in a new tab if the slider is not supported.
+Обрабатывает ошибки, связанные с использованием мобильных устройств, и может открыть URL в новой вкладке, если слайдер не поддерживается.
 
-Returns [`StatusClose`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/slider.ts)
+Возвращает [`StatusClose`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/slider.ts)
 
-| Parameter | Type | Description |
+| Параметр | Тип | Описание |
 |----|----|----|
-| `url` | `URL`{lang="ts-type"} | URL to be opened. |
-| `width` | `number`{lang="ts-type"} | Slider width, a number in the range from `1640` to `900`. |
+| `url` | `URL`{lang="ts-type"} | Открываемый URL. |
+| `width` | `number`{lang="ts-type"} | Ширина слайдера, число в диапазоне от `1640` до `900`. |
 
-This example demonstrates calling the Bitrix24 slider and handling its closing result.
+Этот пример демонстрирует вызов слайдера Bitrix24 и обработку результата его закрытия.
 
-Key points:
+Ключевые моменты:
 
-* **Completion handling:** After closing the slider, the SDK returns a status. This allows subsequent operations to be initiated, such as reinitializing application data.
+* **Обработка завершения:** после закрытия слайдера SDK возвращает статус. Это позволяет запускать последующие операции, например повторную инициализацию данных приложения.
 
 ::warning
-In some cases, Bitrix24 opens the interface not in the slider, but in a new browser tab.
+В некоторых случаях Bitrix24 открывает интерфейс не в слайдере, а в новой вкладке браузера.
 
-* **Limitation:** It is virtually impossible to detect the closing of an individual tab using standard JS tools.
-* **Solution:** The `isOpenAtNewWindow` parameter in the jsSdk response allows you to determine whether a tab was opened instead of the slider and correctly configure the application's logic.
+* **Ограничение:** обнаружить закрытие отдельной вкладки стандартными средствами JS практически невозможно.
+* **Решение:** параметр `isOpenAtNewWindow` в ответе jsSdk позволяет определить, была ли открыта вкладка вместо слайдера, и правильно настроить логику приложения.
 ::
 
 ::code-example
@@ -106,7 +106,7 @@ b24FrameOnly: true
 ```ts-type
 getUrl(path: string = '/'): URL
 ```
-Returns a `URL`{lang="ts-type"} relative to the domain name and path.
+Возвращает `URL`{lang="ts-type"} относительно доменного имени и пути.
 
 ```ts
 $b24 = await initializeB24Frame()
@@ -120,4 +120,4 @@ const url = $b24.slider.getUrl('/settings/configs/userfield_list.php')
 getTargetOrigin(): string
 ```
 
-Returns the Bitrix24 address (e.g., `https://your_domain.bitrix24.com`).
+Возвращает адрес Bitrix24 (например, `https://your_domain.bitrix24.com`).

--- a/docs/content/docs/2.working-with-the-rest-api/40.oauth.md
+++ b/docs/content/docs/2.working-with-the-rest-api/40.oauth.md
@@ -1,6 +1,6 @@
 ---
-title: B24OAuth Class
-description: 'Server-side entry point for talking to the Bitrix24 REST API with an OAuth 2.0 access token (and automatic refresh).'
+title: Класс B24OAuth
+description: 'Серверная точка входа для работы с REST API Bitrix24 по access token OAuth 2.0 (с автоматическим обновлением).'
 category: 'B24OAuth'
 navigation.title: B24OAuth
 links:
@@ -18,42 +18,42 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts
 ---
 
-::caution{title="⚠️ CAUTION: SECURITY"}
-The `B24OAuth`{lang="ts-type"} object is intended **exclusively for use on the server**.
+::caution{title="⚠️ ВНИМАНИЕ: БЕЗОПАСНОСТЬ"}
+Объект `B24OAuth`{lang="ts-type"} предназначен **исключительно для использования на сервере**.
 
-- The `clientSecret`, access token, and refresh token must never appear in browser code.
-- Client-side warning is enabled on both HTTP clients by default; see [`offClientSideWarning`](#offclientsidewarning).
-- For client-side scenarios use [`B24Frame`](/docs/working-with-the-rest-api/frame/).
+- `clientSecret`, access token и refresh token никогда не должны попадать в код браузера.
+- Предупреждение о клиентской стороне по умолчанию включено на обоих HTTP-клиентах; см. [`offClientSideWarning`](#offclientsidewarning).
+- Для клиентских сценариев используйте [`B24Frame`](/docs/working-with-the-rest-api/frame/).
 ::
 
-## Overview {#overview}
+## Обзор {#overview}
 
-`B24OAuth`{lang="ts-type"} is the SDK entry point for [OAuth 2.0 local applications](https://apidocs.bitrix24.ru/settings/oauth/index.html). It accepts an existing token pair (issued by Bitrix24 during installation), uses the access token for REST calls, and refreshes the pair through `oauth.bitrix.info` when the access token expires.
+`B24OAuth`{lang="ts-type"} — это точка входа SDK для [локальных приложений OAuth 2.0](https://apidocs.bitrix24.ru/settings/oauth/index.html). Он принимает существующую пару токенов (выданную Bitrix24 при установке), использует access token для REST-вызовов и обновляет пару через `oauth.bitrix.info`, когда access token истекает.
 
-The class extends `AbstractB24`{lang="ts-type"} and implements [`TypeB24`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts), so the full REST surface (`actions.v2.*`, `actions.v3.*`, `tools.*`) is available immediately after construction — there is no `await b24.init()` step.
+Класс наследуется от `AbstractB24`{lang="ts-type"} и реализует [`TypeB24`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts), поэтому полный набор REST-методов (`actions.v2.*`, `actions.v3.*`, `tools.*`) доступен сразу после создания экземпляра — шаг `await b24.init()` не требуется.
 
-## Creating a B24OAuth Instance {#creating-a-b24oauth-instance}
+## Создание экземпляра B24OAuth {#creating-a-b24oauth-instance}
 
 ```ts
 import { B24OAuth, EnumAppStatus } from '@bitrix24/b24jssdk'
 
 const $b24 = new B24OAuth(
-  // 1) Token data received from Bitrix24 (event payload, OAuth handshake, etc.)
+  // 1) Данные токена, полученные от Bitrix24 (payload события, OAuth-рукопожатие и т.д.)
   {
     applicationToken: '<your_application_token>',
     userId: 1,
     memberId: '<your_member_id>',
     accessToken: '<your_access_token>',
     refreshToken: '<your_refresh_token>',
-    expires: 1745997853,        // unix timestamp, seconds
-    expiresIn: 3600,            // seconds
+    expires: 1745997853,        // unix-таймстамп, секунды
+    expiresIn: 3600,            // секунды
     scope: 'crm,catalog,user_brief',
     domain: 'your_domain.bitrix24.com',
     clientEndpoint: 'https://your_domain.bitrix24.com/rest/',
     serverEndpoint: 'https://oauth.bitrix.info/rest/',
     status: EnumAppStatus.Free
   },
-  // 2) Application credentials issued in Bitrix24 → Developers → Applications
+  // 2) Учётные данные приложения, выданные в Bitrix24 → Разработчикам → Приложения
   {
     clientId: 'local.xxxxxx.xxxxxx',
     clientSecret: '<your_client_secret>'
@@ -67,7 +67,7 @@ const response = await $b24.actions.v2.call.make({
 })
 ```
 
-### Constructor Signature {#constructor-signature}
+### Сигнатура конструктора {#constructor-signature}
 
 ```ts-type
 constructor(
@@ -77,44 +77,44 @@ constructor(
 )
 ```
 
-### `B24OAuthParams` Fields {#b24oauthparams-fields}
+### Поля `B24OAuthParams` {#b24oauthparams-fields}
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `applicationToken` | `string`{lang="ts-type"} | Application token issued at install time. |
-| `userId` | `number`{lang="ts-type"} | Identifier of the user the token belongs to. |
-| `memberId` | `string`{lang="ts-type"} | Portal member id. |
-| `accessToken` | `string`{lang="ts-type"} | Current access token. |
-| `refreshToken` | `string`{lang="ts-type"} | Refresh token used by `refreshAuth`. |
-| `expires` | `number`{lang="ts-type"} | Access token expiration (unix timestamp, **seconds**). |
-| `expiresIn` | `number`{lang="ts-type"} | Token lifetime, seconds. |
-| `scope` | `string`{lang="ts-type"} | Comma-separated scopes (e.g. `crm,catalog,user_brief`). |
-| `domain` | `string`{lang="ts-type"} | Portal domain (`xxx.bitrix24.com`). |
-| `clientEndpoint` | `string`{lang="ts-type"} | Portal REST root, e.g. `https://xxx.bitrix24.com/rest/`. |
-| `serverEndpoint` | `string`{lang="ts-type"} | OAuth server, usually `https://oauth.bitrix.info/rest/`. |
-| `status` | `TypeEnumAppStatus`{lang="ts-type"} | One of `EnumAppStatus.Free / Demo / Trial / Paid / Local / Subscription`. |
+| `applicationToken` | `string`{lang="ts-type"} | Application token, выданный при установке. |
+| `userId` | `number`{lang="ts-type"} | Идентификатор пользователя, которому принадлежит токен. |
+| `memberId` | `string`{lang="ts-type"} | member id портала. |
+| `accessToken` | `string`{lang="ts-type"} | Текущий access token. |
+| `refreshToken` | `string`{lang="ts-type"} | Refresh token, используемый `refreshAuth`. |
+| `expires` | `number`{lang="ts-type"} | Срок действия access token (unix-таймстамп, **секунды**). |
+| `expiresIn` | `number`{lang="ts-type"} | Время жизни токена, секунды. |
+| `scope` | `string`{lang="ts-type"} | Список scope через запятую (например, `crm,catalog,user_brief`). |
+| `domain` | `string`{lang="ts-type"} | Домен портала (`xxx.bitrix24.com`). |
+| `clientEndpoint` | `string`{lang="ts-type"} | Корень REST портала, например `https://xxx.bitrix24.com/rest/`. |
+| `serverEndpoint` | `string`{lang="ts-type"} | OAuth-сервер, обычно `https://oauth.bitrix.info/rest/`. |
+| `status` | `TypeEnumAppStatus`{lang="ts-type"} | Одно из `EnumAppStatus.Free / Demo / Trial / Paid / Local / Subscription`. |
 
-### `B24OAuthSecret` Fields {#b24oauthsecret-fields}
+### Поля `B24OAuthSecret` {#b24oauthsecret-fields}
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `clientId` | `string`{lang="ts-type"} | OAuth `client_id` of your application. |
-| `clientSecret` | `string`{lang="ts-type"} | OAuth `client_secret` of your application. |
+| `clientId` | `string`{lang="ts-type"} | OAuth `client_id` вашего приложения. |
+| `clientSecret` | `string`{lang="ts-type"} | OAuth `client_secret` вашего приложения. |
 
-## Refresh Token Flow {#refresh-token-flow}
+## Процесс обновления токена {#refresh-token-flow}
 
-`B24OAuth`{lang="ts-type"} refreshes the access token automatically when:
+`B24OAuth`{lang="ts-type"} обновляет access token автоматически, когда:
 
-- a REST call returns `expired_token`, **or**
-- `getAuthData()` is called and `expires <= Date.now()`.
+- REST-вызов возвращает `expired_token`, **или**
+- вызывается `getAuthData()` и `expires <= Date.now()`.
 
-The default refresh path calls `GET /oauth/token/` on `serverEndpoint` (typically `https://oauth.bitrix.info/rest/`) with `grant_type=refresh_token`, the supplied `refreshToken`, `clientId`, and `clientSecret`. On success the manager updates `accessToken`, `refreshToken`, `expires`, `expiresIn`, `clientEndpoint`, `serverEndpoint`, `scope`, and `status`.
+Путь обновления по умолчанию вызывает `GET /oauth/token/` на `serverEndpoint` (обычно `https://oauth.bitrix.info/rest/`) с `grant_type=refresh_token`, переданными `refreshToken`, `clientId` и `clientSecret`. При успехе менеджер обновляет `accessToken`, `refreshToken`, `expires`, `expiresIn`, `clientEndpoint`, `serverEndpoint`, `scope` и `status`.
 
-If the refresh request fails, the SDK throws [`RefreshTokenError`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/refresh-token-error.ts) (a subclass of `SdkError`{lang="ts-type"}) carrying `code`, `description`, and HTTP `status`.
+Если запрос обновления завершается неудачей, SDK выбрасывает [`RefreshTokenError`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/refresh-token-error.ts) (подкласс `SdkError`{lang="ts-type"}), несущий `code`, `description` и HTTP-`status`.
 
-### Persisting Refreshed Tokens {#persisting-refreshed-tokens}
+### Сохранение обновлённых токенов {#persisting-refreshed-tokens}
 
-Register a callback so your app can persist the new token pair (DB, secrets manager, etc.):
+Зарегистрируйте callback, чтобы ваше приложение могло сохранить новую пару токенов (БД, менеджер секретов и т.д.):
 
 // @check-ignore: B24OAuth-specific method, ambient $b24 is typed as B24Frame
 ```ts
@@ -129,11 +129,11 @@ $b24.setCallbackRefreshAuth(async ({ authData, b24OAuthParams }) => {
 })
 ```
 
-Remove with `$b24.removeCallbackRefreshAuth()`.
+Удаляется через `$b24.removeCallbackRefreshAuth()`.
 
-### Custom Refresh Logic {#custom-refresh-logic}
+### Кастомная логика обновления {#custom-refresh-logic}
 
-If your app fetches refresh tokens from a separate service (e.g. centralized token broker), supply a `CustomRefreshAuth`{lang="ts-type"} function. The SDK will call it instead of hitting `oauth.bitrix.info`:
+Если ваше приложение получает refresh-токены из отдельного сервиса (например, централизованного брокера токенов), передайте функцию `CustomRefreshAuth`{lang="ts-type"}. SDK вызовет её вместо обращения к `oauth.bitrix.info`:
 
 // @check-ignore: B24OAuth-specific method, ambient $b24 is typed as B24Frame
 ```ts
@@ -156,9 +156,9 @@ $b24.setCustomRefreshAuth(async (): Promise<HandlerRefreshAuth> => {
 })
 ```
 
-Remove with `$b24.removeCustomRefreshAuth()`.
+Удаляется через `$b24.removeCustomRefreshAuth()`.
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### `initIsAdmin` {#initisadmin}
 
@@ -166,7 +166,7 @@ Remove with `$b24.removeCustomRefreshAuth()`.
 initIsAdmin(requestId?: string): Promise<void>
 ```
 
-Calls the `profile` REST method once and caches whether the authenticated user has admin rights. Required before reading [`auth.isAdmin`](#getter-auth) — the getter throws `Error('isAdmin not init. You need call B24OAuth::initIsAdmin().')` when called too early.
+Один раз вызывает REST-метод `profile` и кэширует, есть ли у аутентифицированного пользователя права администратора. Требуется перед чтением [`auth.isAdmin`](#getter-auth) — геттер выбрасывает `Error('isAdmin not init. You need call B24OAuth::initIsAdmin().')`{lang="ts-type"} при слишком раннем вызове.
 
 // @check-ignore: B24OAuth-specific method, ambient $b24 is typed as B24Frame
 ```ts
@@ -183,7 +183,7 @@ setCallbackRefreshAuth(cb: CallbackRefreshAuth): void
 removeCallbackRefreshAuth(): void
 ```
 
-Register / unregister a callback executed after every successful refresh. See [Persisting Refreshed Tokens](#persisting-refreshed-tokens).
+Регистрирует / снимает callback, выполняемый после каждого успешного обновления. См. [Сохранение обновлённых токенов](#persisting-refreshed-tokens).
 
 ### `setCustomRefreshAuth` / `removeCustomRefreshAuth` {#setcustomrefreshauth-removecustomrefreshauth}
 
@@ -192,7 +192,7 @@ setCustomRefreshAuth(cb: CustomRefreshAuth): void
 removeCustomRefreshAuth(): void
 ```
 
-Register / unregister a custom refresh implementation. See [Custom Refresh Logic](#custom-refresh-logic).
+Регистрирует / снимает кастомную реализацию обновления. См. [Кастомная логика обновления](#custom-refresh-logic).
 
 ### `offClientSideWarning` {#offclientsidewarning}
 
@@ -200,7 +200,7 @@ Register / unregister a custom refresh implementation. See [Custom Refresh Logic
 offClientSideWarning(): void
 ```
 
-Disables the runtime warning emitted when `B24OAuth`{lang="ts-type"} is detected in a browser environment. Use only when you proxy the OAuth tokens through a server-side wrapper.
+Отключает runtime-предупреждение, возникающее при обнаружении `B24OAuth`{lang="ts-type"} в браузерном окружении. Используйте только когда вы проксируете OAuth-токены через серверную обёртку.
 
 ### `getTargetOrigin` / `getTargetOriginWithPath` {#gettargetorigin-gettargetoriginwithpath}
 
@@ -209,25 +209,25 @@ getTargetOrigin(): string
 getTargetOriginWithPath(): Map<ApiVersion, string>
 ```
 
-Return the portal origin (e.g. `https://xxx.bitrix24.com`) and the per-version REST endpoints derived from `clientEndpoint`.
+Возвращают origin портала (например, `https://xxx.bitrix24.com`) и REST-endpoint-ы для каждой версии, выведенные из `clientEndpoint`.
 
 ### `getHttpClient` / `setHttpClient` / `setRestrictionManagerParams` / `getLogger` / `setLogger` / `destroy` {#gethttpclient-sethttpclient-setrestrictionmanagerparams-getlogger-setlogger-destroy}
 
-Inherited from `AbstractB24`{lang="ts-type"} — same shape as on `B24Hook`{lang="ts-type"} and `B24Frame`{lang="ts-type"}. See:
+Унаследованы от `AbstractB24`{lang="ts-type"} — та же структура, что и у `B24Hook`{lang="ts-type"} и `B24Frame`{lang="ts-type"}. См.:
 
-- [Limiters](/docs/working-with-the-rest-api/limiters/) — `setRestrictionManagerParams`.
-- [Logger](/docs/working-with-the-rest-api/logger/) — `getLogger` / `setLogger`.
+- [Лимитеры](/docs/working-with-the-rest-api/limiters/) — `setRestrictionManagerParams`.
+- [Логгер](/docs/working-with-the-rest-api/logger/) — `getLogger` / `setLogger`.
 
-## Getters {#getters}
+## Геттеры {#getters}
 
 ### `auth` {#auth}
 
-Returns the [`AuthOAuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/auth.ts) instance, which implements [`AuthActions`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts):
+Возвращает экземпляр [`AuthOAuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/auth.ts), который реализует [`AuthActions`{lang="ts-type"}](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts):
 
-- `getAuthData()` — returns current `AuthData`{lang="ts-type"} or `false`{lang="ts-type"} if the access token has expired (the next REST call will trigger an automatic refresh).
-- `refreshAuth()` — manual refresh; throws `RefreshTokenError`{lang="ts-type"} on failure.
-- `getUniq(prefix: string)` — returns `<prefix>_<memberId>`{lang="ts-type"}.
-- `isAdmin` — requires `initIsAdmin()` first.
+- `getAuthData()` — возвращает текущий `AuthData`{lang="ts-type"} или `false`{lang="ts-type"}, если access token истёк (следующий REST-вызов вызовет автоматическое обновление).
+- `refreshAuth()` — ручное обновление; выбрасывает `RefreshTokenError`{lang="ts-type"} при неудаче.
+- `getUniq(prefix: string)` — возвращает `<prefix>_<memberId>`{lang="ts-type"}.
+- `isAdmin` — требует предварительного вызова `initIsAdmin()`.
 
 ### `isInit` {#isinit}
 
@@ -235,9 +235,9 @@ Returns the [`AuthOAuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/
 get isInit(): boolean
 ```
 
-Always `true`{lang="ts-type"} immediately after construction.
+Всегда `true`{lang="ts-type"} сразу после создания экземпляра.
 
-## Error Handling {#error-handling}
+## Обработка ошибок {#error-handling}
 
 // @check-ignore: top-level return in error-handling illustration
 ```ts
@@ -250,12 +250,12 @@ try {
     requestId: 'task-get-1'
   })
   if (!response.isSuccess) {
-    // Handle REST-level errors
+    // Обработка ошибок уровня REST
     console.error(response.getErrorMessages())
   }
 } catch (error) {
   if (error instanceof RefreshTokenError) {
-    // Refresh token is dead — re-authorize the application
+    // Refresh token мёртв — переавторизуйте приложение
     console.error('OAuth refresh failed:', error.message)
     return
   }
@@ -267,20 +267,20 @@ try {
 
 ::accordion
 
-:::accordion-item{label="Where do I get the initial token pair?"}
-Bitrix24 sends them when your local application is installed and again on the [`ONAPPINSTALL` / `ONAPPUPDATE`](https://apidocs.bitrix24.ru/api-reference/events/index.html) events. Persist them and pass to `B24OAuth`{lang="ts-type"} on every server start.
+:::accordion-item{label="Где взять начальную пару токенов?"}
+Bitrix24 отправляет их при установке вашего локального приложения и повторно на событиях [`ONAPPINSTALL` / `ONAPPUPDATE`](https://apidocs.bitrix24.ru/api-reference/events/index.html). Сохраняйте их и передавайте в `B24OAuth`{lang="ts-type"} при каждом старте сервера.
 :::
 
-:::accordion-item{label="Why is `expires` in seconds, not milliseconds?"}
-Bitrix24 returns Unix timestamps in seconds. The SDK converts internally; you must pass seconds in `B24OAuthParams.expires`.
+:::accordion-item{label="Почему `expires` в секундах, а не в миллисекундах?"}
+Bitrix24 возвращает Unix-таймстампы в секундах. SDK конвертирует внутри; вы должны передавать секунды в `B24OAuthParams.expires`.
 :::
 
-:::accordion-item{label="Can I share one B24OAuth instance across requests?"}
-Yes — and you should. Sharing keeps the limiter state and the in-memory access token consistent. Persist the refreshed token pair via `setCallbackRefreshAuth` so a restart reuses the latest tokens.
+:::accordion-item{label="Можно ли использовать один экземпляр B24OAuth между запросами?"}
+Да — и нужно. Совместное использование сохраняет состояние лимитера и access token в памяти согласованными. Сохраняйте обновлённую пару токенов через `setCallbackRefreshAuth`, чтобы после перезапуска использовались последние токены.
 :::
 
-:::accordion-item{label="What about read-only methods that don't need admin rights?"}
-You can skip `initIsAdmin()` if your code never reads `auth.isAdmin`. REST calls themselves do not depend on it.
+:::accordion-item{label="А как насчёт методов только для чтения, которым не нужны права администратора?"}
+Вы можете пропустить `initIsAdmin()`, если ваш код никогда не читает `auth.isAdmin`. Сами REST-вызовы от него не зависят.
 :::
 
 ::

--- a/docs/content/docs/2.working-with-the-rest-api/50.helper.md
+++ b/docs/content/docs/2.working-with-the-rest-api/50.helper.md
@@ -1,6 +1,6 @@
 ---
 title: B24HelperManager
-description: 'Aggregate manager that loads profile, app, payment, license, currency, and options data with one batched REST call, plus wires the Pull client.'
+description: 'Агрегирующий менеджер, который загружает данные профиля, приложения, оплаты, лицензии, валют и опций одним батч-запросом REST, а также подключает Pull-клиент.'
 category: 'Helper'
 navigation.title: B24HelperManager
 links:
@@ -12,11 +12,11 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts
 ---
 
-## Overview {#overview}
+## Обзор {#overview}
 
-`B24HelperManager`{lang="ts-type"} batches a single REST call (`profile`, `app.info`, `crm.currency.base.get`, `crm.currency.list`, `app.option.get`, `user.option.get`) and exposes the parsed result through specialised sub-managers. It also owns the [Pull client](/docs/working-with-the-rest-api/pull/) lifecycle — connect, subscribe, start, destroy.
+`B24HelperManager`{lang="ts-type"} объединяет в один REST-вызов (`profile`, `app.info`, `crm.currency.base.get`, `crm.currency.list`, `app.option.get`, `user.option.get`) и предоставляет разобранный результат через специализированные суб-менеджеры. Он также владеет жизненным циклом [Pull-клиента](/docs/working-with-the-rest-api/pull/) — подключение, подписка, запуск, уничтожение.
 
-You will normally interact with `B24HelperManager`{lang="ts-type"} indirectly, through the [`useB24Helper`](/docs/working-with-the-rest-api/helper-use-b24-helper/) composable. Direct construction is supported but rarely needed.
+Обычно вы взаимодействуете с `B24HelperManager`{lang="ts-type"} косвенно — через composable [`useB24Helper`](/docs/working-with-the-rest-api/helper-use-b24-helper/). Прямое создание поддерживается, но требуется редко.
 
 ```ts
 import { useB24Helper, LoadDataType, initializeB24Frame } from '@bitrix24/b24jssdk'
@@ -36,15 +36,15 @@ const helper = getB24Helper()
 console.log(helper.profileInfo.data, helper.appInfo.data)
 ```
 
-## Constructor {#constructor}
+## Конструктор {#constructor}
 
 ```ts-type
 constructor(b24: TypeB24)
 ```
 
-Accepts any `TypeB24`{lang="ts-type"} instance — `B24Frame`{lang="ts-type"}, `B24Hook`{lang="ts-type"}, or `B24OAuth`{lang="ts-type"}. The helper does **not** call `init()` for you; the wrapped instance must already be initialized before `loadData()` runs.
+Принимает любой экземпляр `TypeB24`{lang="ts-type"} — `B24Frame`{lang="ts-type"}, `B24Hook`{lang="ts-type"} или `B24OAuth`{lang="ts-type"}. Хелпер **не** вызывает `init()` за вас; обёрнутый экземпляр должен быть уже инициализирован до запуска `loadData()`.
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### `loadData` {#loaddata}
 
@@ -55,15 +55,15 @@ loadData(
 ): Promise<void>
 ```
 
-Fetches the requested data slices via `actions.v2.batch.make({ isHaltOnError: true })`. After this resolves, the matching getters (`profileInfo`, `appInfo`, etc.) become available; before that they throw `'B24HelperManager not initialized'`{lang="ts-type"}.
+Получает запрошенные срезы данных через `actions.v2.batch.make({ isHaltOnError: true })`. После разрешения соответствующие геттеры (`profileInfo`, `appInfo` и т.д.) становятся доступны; до этого они выбрасывают `'B24HelperManager not initialized'`{lang="ts-type"}.
 
-`dataTypes` defaults to `[LoadDataType.App, LoadDataType.Profile]`{lang="ts-type"}.
+`dataTypes` по умолчанию `[LoadDataType.App, LoadDataType.Profile]`{lang="ts-type"}.
 
-`requestId` defaults to `'helper-load-data'`. Override it for traceability.
+`requestId` по умолчанию `'helper-load-data'`. Переопределите его для трассируемости.
 
-#### `LoadDataType` enum
+#### Enum `LoadDataType`
 
-| Value | REST methods invoked | Resulting manager |
+| Значение | Вызываемые REST-методы | Результирующий менеджер |
 |----|----|----|
 | `App` | `app.info` | [`appInfo`](/docs/working-with-the-rest-api/helper-app-manager/), [`paymentInfo`](/docs/working-with-the-rest-api/helper-payment-manager/), [`licenseInfo`](/docs/working-with-the-rest-api/helper-license-manager/) |
 | `Profile` | `profile` | [`profileInfo`](/docs/working-with-the-rest-api/helper-profile-manager/) |
@@ -78,7 +78,7 @@ getLogger(): LoggerInterface
 setLogger(logger: LoggerInterface): void
 ```
 
-`setLogger` propagates the logger into every parsed sub-manager. Defaults to `LoggerFactory.createNullLogger()`{lang="ts-type"}.
+`setLogger` распространяет логгер во все разобранные суб-менеджеры. По умолчанию `LoggerFactory.createNullLogger()`{lang="ts-type"}.
 
 ### `destroy` {#destroy}
 
@@ -86,9 +86,9 @@ setLogger(logger: LoggerInterface): void
 destroy(): void
 ```
 
-Tears down the Pull client (unsubscribe + disconnect). Idempotent.
+Разрушает Pull-клиент (отписка + отключение). Идемпотентен.
 
-### Pull client glue {#pull-client-glue}
+### Связка с Pull-клиентом {#pull-client-glue}
 
 ```ts-type
 usePullClient(prefix?: string, userId?: number): B24HelperManager
@@ -97,12 +97,12 @@ startPullClient(): void
 getModuleIdPullClient(): string
 ```
 
-Order matters: `usePullClient()` → `subscribePullClient()` (one or more times) → `startPullClient()`. See [Pull client](/docs/working-with-the-rest-api/pull/) for the full flow. `getModuleIdPullClient()` returns the `moduleId` last passed to `subscribePullClient`, intended for `pull.application.event.add` payloads.
+Порядок важен: `usePullClient()` → `subscribePullClient()` (один или несколько раз) → `startPullClient()`. Полный процесс см. в [Pull-клиент](/docs/working-with-the-rest-api/pull/). `getModuleIdPullClient()` возвращает `moduleId`, последним переданный в `subscribePullClient`, предназначен для payload `pull.application.event.add`.
 
-## Getters {#getters}
+## Геттеры {#getters}
 
 ::caution
-All getters listed below throw `'B24HelperManager not initialized'`{lang="ts-type"} until `loadData()` resolves. Each individual getter additionally throws when the relevant `LoadDataType` was not requested.
+Все перечисленные ниже геттеры выбрасывают `'B24HelperManager not initialized'`{lang="ts-type"} до разрешения `loadData()`. Каждый отдельный геттер дополнительно выбрасывает исключение, если соответствующий `LoadDataType` не был запрошен.
 ::
 
 ### `isInit` {#isinit}
@@ -111,11 +111,11 @@ All getters listed below throw `'B24HelperManager not initialized'`{lang="ts-typ
 get isInit(): boolean
 ```
 
-`true`{lang="ts-type"} once `loadData()` has finished successfully.
+`true`{lang="ts-type"} после успешного завершения `loadData()`.
 
 ### `profileInfo` / `appInfo` / `paymentInfo` / `licenseInfo` / `currency` / `appOptions` / `userOptions` {#profileinfo-appinfo-paymentinfo-licenseinfo-currency-appoptions-useroptions}
 
-Return the parsed sub-manager. See:
+Возвращают разобранный суб-менеджер. См.:
 
 - [ProfileManager](/docs/working-with-the-rest-api/helper-profile-manager/)
 - [AppManager](/docs/working-with-the-rest-api/helper-app-manager/)
@@ -130,17 +130,17 @@ Return the parsed sub-manager. See:
 get forB24Form(): TypeB24Form
 ```
 
-Returns a flat object suitable for posting to a Bitrix24 [CRM feedback form](https://github.com/bitrix24/b24sdk-examples/blob/main/js/03-nuxt-frame/pages/feedback.client.vue). Requires both `LoadDataType.App` and `LoadDataType.Profile`.
+Возвращает плоский объект, подходящий для отправки в [форму обратной связи CRM](https://github.com/bitrix24/b24sdk-examples/blob/main/js/03-nuxt-frame/pages/feedback.client.vue) Bitrix24. Требует одновременно `LoadDataType.App` и `LoadDataType.Profile`.
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `app_code` | `string`{lang="ts-type"} | Application code in Bitrix24. |
-| `app_status` | `string`{lang="ts-type"} | Application status (`F` / `D` / `T` / `P` / `L` / `S`). |
-| `payment_expired` | `BoolString`{lang="ts-type"} | `'Y'` if the paid/trial period is over, else `'N'`. |
-| `days` | `number`{lang="ts-type"} | Days remaining until / since expiration. |
-| `b24_plan` | `string`{lang="ts-type"} | Bitrix24 cloud tariff identifier. |
-| `c_name` / `c_last_name` | `string`{lang="ts-type"} | Profile name / last name. |
-| `hostname` | `string`{lang="ts-type"} | Portal address (e.g. `xxx.bitrix24.com`). |
+| `app_code` | `string`{lang="ts-type"} | Код приложения в Bitrix24. |
+| `app_status` | `string`{lang="ts-type"} | Статус приложения (`F` / `D` / `T` / `P` / `L` / `S`). |
+| `payment_expired` | `BoolString`{lang="ts-type"} | `'Y'`, если платный/пробный период закончился, иначе `'N'`. |
+| `days` | `number`{lang="ts-type"} | Дней до / после окончания. |
+| `b24_plan` | `string`{lang="ts-type"} | Идентификатор облачного тарифа Bitrix24. |
+| `c_name` / `c_last_name` | `string`{lang="ts-type"} | Имя / фамилия из профиля. |
+| `hostname` | `string`{lang="ts-type"} | Адрес портала (например, `xxx.bitrix24.com`). |
 
 ### `hostName` {#hostname}
 
@@ -148,7 +148,7 @@ Returns a flat object suitable for posting to a Bitrix24 [CRM feedback form](htt
 get hostName(): string
 ```
 
-Portal origin (`https://xxx.bitrix24.com`). Backed by `b24.getTargetOrigin()`.
+Origin портала (`https://xxx.bitrix24.com`). Опирается на `b24.getTargetOrigin()`.
 
 ### `isSelfHosted` {#isselfhosted}
 
@@ -156,7 +156,7 @@ Portal origin (`https://xxx.bitrix24.com`). Backed by `b24.getTargetOrigin()`.
 get isSelfHosted(): boolean
 ```
 
-`true`{lang="ts-type"} when the license string contains `selfhosted`. Requires `LoadDataType.App`.
+`true`{lang="ts-type"}, когда строка лицензии содержит `selfhosted`. Требует `LoadDataType.App`.
 
 ### `primaryKeyIncrementValue` {#primarykeyincrementvalue}
 
@@ -164,7 +164,7 @@ get isSelfHosted(): boolean
 get primaryKeyIncrementValue(): number
 ```
 
-Returns the increment step for ID-typed fields: `1`{lang="ts-type"} on self-hosted, `2`{lang="ts-type"} on cloud.
+Возвращает шаг инкремента для полей типа ID: `1`{lang="ts-type"} на self-hosted, `2`{lang="ts-type"} в облаке.
 
 ### `b24SpecificUrl` {#b24specificurl}
 
@@ -172,9 +172,9 @@ Returns the increment step for ID-typed fields: `1`{lang="ts-type"} on self-host
 get b24SpecificUrl(): Record<keyof typeof TypeSpecificUrl, string>
 ```
 
-Returns admin-area URLs that differ between cloud and self-hosted:
+Возвращает URL-ы админ-зоны, различающиеся между облаком и self-hosted:
 
-| Key | Cloud | Self-hosted |
+| Ключ | Облако | Self-hosted |
 |----|----|----|
 | `MainSettings` | `/settings/configs/` | `/configs/` |
 | `UfList` | `/settings/configs/userfield_list.php` | `/configs/userfield_list.php` |

--- a/docs/content/docs/2.working-with-the-rest-api/51.helper-use-b24-helper.md
+++ b/docs/content/docs/2.working-with-the-rest-api/51.helper-use-b24-helper.md
@@ -1,6 +1,6 @@
 ---
-title: useB24Helper Composable
-description: 'Closure-based composable that owns a single B24HelperManager instance and exposes lifecycle helpers (init / destroy / Pull client glue).'
+title: Composable useB24Helper
+description: 'Основанный на замыкании composable, который владеет единственным экземпляром B24HelperManager и предоставляет хелперы жизненного цикла (init / destroy / связка с Pull-клиентом).'
 category: 'Helper'
 navigation.title: useB24Helper
 links:
@@ -12,9 +12,9 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/helper/helper-manager.ts
 ---
 
-## Overview {#overview}
+## Обзор {#overview}
 
-`useB24Helper()`{lang="ts-type"} is a factory: each call returns a new closure with its own [`B24HelperManager`](/docs/working-with-the-rest-api/helper/) slot and Pull-client state. It deduplicates init across re-renders and centralises destroy-on-unmount.
+`useB24Helper()`{lang="ts-type"} — это фабрика: каждый вызов возвращает новое замыкание с собственным слотом [`B24HelperManager`](/docs/working-with-the-rest-api/helper/) и состоянием Pull-клиента. Оно устраняет дублирование инициализации между перерисовками и централизует уничтожение при размонтировании.
 
 ```ts
 import { useB24Helper, LoadDataType } from '@bitrix24/b24jssdk'
@@ -30,7 +30,7 @@ const {
 } = useB24Helper()
 ```
 
-## Returned API {#returned-api}
+## Возвращаемый API {#returned-api}
 
 ### `initB24Helper` {#initb24helper}
 
@@ -42,7 +42,7 @@ initB24Helper(
 ): Promise<B24HelperManager>
 ```
 
-Creates a `B24HelperManager`{lang="ts-type"} (once per closure) and calls `loadData(dataTypes, requestId)`. Subsequent invocations are no-ops — they return the same manager without re-fetching. `dataTypes` defaults to `[LoadDataType.App, LoadDataType.Profile]`{lang="ts-type"}; `requestId` defaults to `'helper-load-data'`{lang="ts-type"}.
+Создаёт `B24HelperManager`{lang="ts-type"} (один раз на замыкание) и вызывает `loadData(dataTypes, requestId)`. Последующие вызовы ничего не делают — они возвращают тот же менеджер без повторной загрузки. `dataTypes` по умолчанию `[LoadDataType.App, LoadDataType.Profile]`{lang="ts-type"}; `requestId` по умолчанию `'helper-load-data'`{lang="ts-type"}.
 
 ### `isInitB24Helper` {#isinitb24helper}
 
@@ -50,7 +50,7 @@ Creates a `B24HelperManager`{lang="ts-type"} (once per closure) and calls `loadD
 isInitB24Helper(): boolean
 ```
 
-Returns `true`{lang="ts-type"} after `initB24Helper` has resolved at least once.
+Возвращает `true`{lang="ts-type"} после того, как `initB24Helper` разрешился хотя бы один раз.
 
 ### `destroyB24Helper` {#destroyb24helper}
 
@@ -58,7 +58,7 @@ Returns `true`{lang="ts-type"} after `initB24Helper` has resolved at least once.
 destroyB24Helper(): void
 ```
 
-Calls `destroy()` on the underlying manager (closing the Pull client) and resets the closure flags so a new `initB24Helper` call will re-fetch from scratch.
+Вызывает `destroy()` на нижележащем менеджере (закрывая Pull-клиент) и сбрасывает флаги замыкания, чтобы новый вызов `initB24Helper` загрузил данные заново.
 
 ### `getB24Helper` {#getb24helper}
 
@@ -66,9 +66,9 @@ Calls `destroy()` on the underlying manager (closing the Pull client) and resets
 getB24Helper(): B24HelperManager
 ```
 
-Returns the live manager. Throws `'B24HelperManager is not initialized. You need to call initB24Helper first.'`{lang="ts-type"} when called before `initB24Helper`.
+Возвращает активный менеджер. Выбрасывает `'B24HelperManager is not initialized. You need to call initB24Helper first.'`{lang="ts-type"} при вызове до `initB24Helper`.
 
-### Pull client helpers {#pull-client-helpers}
+### Хелперы Pull-клиента {#pull-client-helpers}
 
 ```ts-type
 usePullClient(): void
@@ -76,9 +76,9 @@ useSubscribePullClient(callback: (message: TypePullMessage) => void, moduleId?: 
 startPullClient(): void
 ```
 
-Thin wrappers over the matching `B24HelperManager`{lang="ts-type"} methods. Order: `usePullClient` → `useSubscribePullClient` (one or more) → `startPullClient`. Calling `useSubscribePullClient` or `startPullClient` before `usePullClient` throws `'PullClient is not initialized. You need to call usePullClient first.'`{lang="ts-type"}. See [Pull client](/docs/working-with-the-rest-api/pull/).
+Тонкие обёртки над соответствующими методами `B24HelperManager`{lang="ts-type"}. Порядок: `usePullClient` → `useSubscribePullClient` (один или несколько) → `startPullClient`. Вызов `useSubscribePullClient` или `startPullClient` до `usePullClient` выбрасывает `'PullClient is not initialized. You need to call usePullClient first.'`{lang="ts-type"}. См. [Pull-клиент](/docs/working-with-the-rest-api/pull/).
 
-## `LoadDataType` Enum {#loaddatatype-enum}
+## Enum `LoadDataType` {#loaddatatype-enum}
 
 ```ts-type
 enum LoadDataType {
@@ -90,9 +90,9 @@ enum LoadDataType {
 }
 ```
 
-Each value drives one (or two for `Currency`) REST methods inside the batch — see the table on the [B24HelperManager](/docs/working-with-the-rest-api/helper/#loaddatatype-enum) page.
+Каждое значение запускает один (или два для `Currency`) REST-метод внутри батча — см. таблицу на странице [B24HelperManager](/docs/working-with-the-rest-api/helper/#loaddatatype-enum).
 
-## Vue Example {#vue-example}
+## Пример на Vue {#vue-example}
 
 ```vue
 <script setup lang="ts">

--- a/docs/content/docs/2.working-with-the-rest-api/52.helper-profile-manager.md
+++ b/docs/content/docs/2.working-with-the-rest-api/52.helper-profile-manager.md
@@ -1,6 +1,6 @@
 ---
 title: ProfileManager
-description: 'Parsed `profile` REST response: id, name, last name, gender, photo, time zone, admin flag.'
+description: 'Разобранный ответ REST-метода `profile`: id, имя, фамилия, пол, фото, часовой пояс, флаг администратора.'
 category: 'Helper'
 navigation.title: ProfileManager
 links:
@@ -12,9 +12,9 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts
 ---
 
-`ProfileManager`{lang="ts-type"} wraps the response of the `profile` REST method. Created by [`B24HelperManager.loadData`](/docs/working-with-the-rest-api/helper/#loaddata) when `LoadDataType.Profile` is requested; reachable through [`B24HelperManager.profileInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
+`ProfileManager`{lang="ts-type"} оборачивает ответ REST-метода `profile`. Создаётся через [`B24HelperManager.loadData`](/docs/working-with-the-rest-api/helper/#loaddata), когда запрошен `LoadDataType.Profile`; доступен через [`B24HelperManager.profileInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import { useB24Helper, LoadDataType } from '@bitrix24/b24jssdk'
@@ -26,23 +26,23 @@ const profile = getB24Helper().profileInfo.data
 console.log(profile.id, profile.name, profile.lastName, profile.isAdmin)
 ```
 
-## Getter `data` {#getter-data}
+## Геттер `data` {#getter-data}
 
 ```ts-type
 get data(): TypeUser
 ```
 
-Returns the typed profile snapshot. Throws `'ProfileManager.data not initialized'`{lang="ts-type"} if `loadData` has not been called yet.
+Возвращает типизированный снимок профиля. Выбрасывает `'ProfileManager.data not initialized'`{lang="ts-type"}, если `loadData` ещё не был вызван.
 
-### `TypeUser` Fields {#typeuser-fields}
+### Поля `TypeUser` {#typeuser-fields}
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `id` | `null \| number`{lang="ts-type"} | User identifier. |
-| `isAdmin` | `boolean`{lang="ts-type"} | `true` if the user has admin rights on the portal. |
-| `name` | `null \| string`{lang="ts-type"} | First name. |
-| `lastName` | `null \| string`{lang="ts-type"} | Last name. |
-| `gender` | `'M' \| 'F' \| ''`{lang="ts-type"} | `'M' / 'F' / ''` (no value). |
-| `photo` | `null \| string`{lang="ts-type"} | Profile photo URL. |
-| `TimeZone` | `null \| string`{lang="ts-type"} | IANA time zone (e.g. `Europe/Moscow`). |
-| `TimeZoneOffset` | `null \| number`{lang="ts-type"} | Offset in seconds. |
+| `id` | `null \| number`{lang="ts-type"} | Идентификатор пользователя. |
+| `isAdmin` | `boolean`{lang="ts-type"} | `true`, если у пользователя есть права администратора на портале. |
+| `name` | `null \| string`{lang="ts-type"} | Имя. |
+| `lastName` | `null \| string`{lang="ts-type"} | Фамилия. |
+| `gender` | `'M' \| 'F' \| ''`{lang="ts-type"} | `'M' / 'F' / ''` (нет значения). |
+| `photo` | `null \| string`{lang="ts-type"} | URL фото профиля. |
+| `TimeZone` | `null \| string`{lang="ts-type"} | Часовой пояс IANA (например, `Europe/Moscow`). |
+| `TimeZoneOffset` | `null \| number`{lang="ts-type"} | Смещение в секундах. |

--- a/docs/content/docs/2.working-with-the-rest-api/53.helper-app-manager.md
+++ b/docs/content/docs/2.working-with-the-rest-api/53.helper-app-manager.md
@@ -1,6 +1,6 @@
 ---
 title: AppManager
-description: 'Parsed `app.info` REST response: app id, code, version, status, install flag.'
+description: 'Разобранный ответ REST-метода `app.info`: id приложения, код, версия, статус, флаг установки.'
 category: 'Helper'
 navigation.title: AppManager
 links:
@@ -12,9 +12,9 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts
 ---
 
-`AppManager`{lang="ts-type"} wraps the response of `app.info`. Created by [`B24HelperManager.loadData`](/docs/working-with-the-rest-api/helper/#loaddata) when `LoadDataType.App` is requested; reachable through [`B24HelperManager.appInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
+`AppManager`{lang="ts-type"} оборачивает ответ `app.info`. Создаётся через [`B24HelperManager.loadData`](/docs/working-with-the-rest-api/helper/#loaddata), когда запрошен `LoadDataType.App`; доступен через [`B24HelperManager.appInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import { useB24Helper, LoadDataType } from '@bitrix24/b24jssdk'
@@ -26,29 +26,29 @@ const app = getB24Helper().appInfo
 console.log(app.data.code, app.data.version, app.statusCode)
 ```
 
-## Getter `data` {#getter-data}
+## Геттер `data` {#getter-data}
 
 ```ts-type
 get data(): TypeApp
 ```
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `id` | `number`{lang="ts-type"} | Local application identifier on the portal. |
-| `code` | `string`{lang="ts-type"} | Application code (`local.xxxxxx.xxxxxx`). |
-| `version` | `number`{lang="ts-type"} | Installed version. |
-| `status` | `TypeEnumAppStatus`{lang="ts-type"} | One of `'F' / 'D' / 'T' / 'P' / 'L' / 'S'`. |
-| `isInstalled` | `boolean`{lang="ts-type"} | Install flag from Bitrix24. |
+| `id` | `number`{lang="ts-type"} | Идентификатор локального приложения на портале. |
+| `code` | `string`{lang="ts-type"} | Код приложения (`local.xxxxxx.xxxxxx`). |
+| `version` | `number`{lang="ts-type"} | Установленная версия. |
+| `status` | `TypeEnumAppStatus`{lang="ts-type"} | Одно из `'F' / 'D' / 'T' / 'P' / 'L' / 'S'`. |
+| `isInstalled` | `boolean`{lang="ts-type"} | Флаг установки от Bitrix24. |
 
-## Getter `statusCode` {#getter-statuscode}
+## Геттер `statusCode` {#getter-statuscode}
 
 ```ts-type
 get statusCode(): string
 ```
 
-Resolves the raw `status` letter to a human-readable label using the `StatusDescriptions`{lang="ts-type"} table:
+Преобразует исходную букву `status` в человекочитаемую метку, используя таблицу `StatusDescriptions`{lang="ts-type"}:
 
-| Raw | `statusCode` |
+| Буква | `statusCode` |
 |----|----|
 | `F` | `Free` |
 | `D` | `Demo` |
@@ -57,4 +57,4 @@ Resolves the raw `status` letter to a human-readable label using the `StatusDesc
 | `L` | `Local` |
 | `S` | `Subscription` |
 
-Returns `'Unknown status'`{lang="ts-type"} for unknown letters.
+Возвращает `'Unknown status'`{lang="ts-type"} для неизвестных букв.

--- a/docs/content/docs/2.working-with-the-rest-api/54.helper-payment-manager.md
+++ b/docs/content/docs/2.working-with-the-rest-api/54.helper-payment-manager.md
@@ -1,6 +1,6 @@
 ---
 title: PaymentManager
-description: 'Payment status of a Bitrix24 application — extracted from `app.info`.'
+description: 'Статус оплаты приложения Bitrix24 — извлекается из `app.info`.'
 category: 'Helper'
 navigation.title: PaymentManager
 links:
@@ -12,9 +12,9 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts
 ---
 
-`PaymentManager`{lang="ts-type"} wraps the payment-related fields of `app.info` (`PAYMENT_EXPIRED`, `DAYS`). Created when `LoadDataType.App` is requested; reachable through [`B24HelperManager.paymentInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
+`PaymentManager`{lang="ts-type"} оборачивает связанные с оплатой поля `app.info` (`PAYMENT_EXPIRED`, `DAYS`). Создаётся, когда запрошен `LoadDataType.App`; доступен через [`B24HelperManager.paymentInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import { useB24Helper, LoadDataType } from '@bitrix24/b24jssdk'
@@ -28,13 +28,13 @@ if (payment.isExpired) {
 }
 ```
 
-## Getter `data` {#getter-data}
+## Геттер `data` {#getter-data}
 
 ```ts-type
 get data(): TypePayment
 ```
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `isExpired` | `boolean`{lang="ts-type"} | `true` once the paid period or the trial has ended. |
-| `days` | `number`{lang="ts-type"} | Days remaining (when `isExpired === false`) or days since expiration (when `isExpired === true`). |
+| `isExpired` | `boolean`{lang="ts-type"} | `true`, когда платный период или пробный период закончился. |
+| `days` | `number`{lang="ts-type"} | Оставшиеся дни (когда `isExpired === false`) или дни с момента окончания (когда `isExpired === true`). |

--- a/docs/content/docs/2.working-with-the-rest-api/55.helper-license-manager.md
+++ b/docs/content/docs/2.working-with-the-rest-api/55.helper-license-manager.md
@@ -1,6 +1,6 @@
 ---
 title: LicenseManager
-description: 'Bitrix24 license info from `app.info` — and an automatic restriction-manager retune for the matching tariff plan.'
+description: 'Информация о лицензии Bitrix24 из `app.info` — и автоматическая перенастройка менеджера ограничений под соответствующий тарифный план.'
 category: 'Helper'
 navigation.title: LicenseManager
 links:
@@ -15,13 +15,13 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts
 ---
 
-`LicenseManager`{lang="ts-type"} wraps the license fields of `app.info` (`LICENSE`, `LICENSE_TYPE`, `LICENSE_FAMILY`, `LICENSE_PREVIOUS`, `LANGUAGE_ID`). Created when `LoadDataType.App` is requested; reachable through [`B24HelperManager.licenseInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
+`LicenseManager`{lang="ts-type"} оборачивает поля лицензии `app.info` (`LICENSE`, `LICENSE_TYPE`, `LICENSE_FAMILY`, `LICENSE_PREVIOUS`, `LANGUAGE_ID`). Создаётся, когда запрошен `LoadDataType.App`; доступен через [`B24HelperManager.licenseInfo`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
 
 ::note
-On `initData`, `LicenseManager`{lang="ts-type"} calls [`ParamsFactory.fromTariffPlan(license)`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/params-factory.ts) and applies the result via `b24.setRestrictionManagerParams(...)`. That swaps in enterprise-grade rate limits when the portal is on an enterprise tariff. See [Limiters](/docs/working-with-the-rest-api/limiters/).
+При `initData` `LicenseManager`{lang="ts-type"} вызывает [`ParamsFactory.fromTariffPlan(license)`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/params-factory.ts) и применяет результат через `b24.setRestrictionManagerParams(...)`. Это подставляет enterprise-уровень rate limit, когда портал на enterprise-тарифе. См. [Лимитеры](/docs/working-with-the-rest-api/limiters/).
 ::
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import { useB24Helper, LoadDataType } from '@bitrix24/b24jssdk'
@@ -33,25 +33,25 @@ const license = getB24Helper().licenseInfo.data
 console.log(license.license, license.isSelfHosted)
 ```
 
-## Getter `data` {#getter-data}
+## Геттер `data` {#getter-data}
 
 ```ts-type
 get data(): TypeLicense
 ```
 
-| Field | Type | Description |
+| Поле | Тип | Описание |
 |----|----|----|
-| `languageId` | `null \| string`{lang="ts-type"} | Portal language code. |
-| `license` | `null \| string`{lang="ts-type"} | Tariff designation prefixed with the region (`ru_team`, `b24_enterprise`, …). |
-| `licenseType` | `null \| string`{lang="ts-type"} | Tariff designation without the region prefix. |
-| `licensePrevious` | `null \| string`{lang="ts-type"} | Previous license (when applicable). |
-| `licenseFamily` | `null \| string`{lang="ts-type"} | Tariff family (`team`, `enterprise`, …). |
-| `isSelfHosted` | `boolean`{lang="ts-type"} | `true` if `license` contains `selfhosted`. |
+| `languageId` | `null \| string`{lang="ts-type"} | Код языка портала. |
+| `license` | `null \| string`{lang="ts-type"} | Обозначение тарифа с префиксом региона (`ru_team`, `b24_enterprise`, …). |
+| `licenseType` | `null \| string`{lang="ts-type"} | Обозначение тарифа без префикса региона. |
+| `licensePrevious` | `null \| string`{lang="ts-type"} | Предыдущая лицензия (если применимо). |
+| `licenseFamily` | `null \| string`{lang="ts-type"} | Семейство тарифа (`team`, `enterprise`, …). |
+| `isSelfHosted` | `boolean`{lang="ts-type"} | `true`, если `license` содержит `selfhosted`. |
 
-## Method `makeRestrictionManagerParams` {#method-makerestrictionmanagerparams}
+## Метод `makeRestrictionManagerParams` {#method-makerestrictionmanagerparams}
 
 ```ts-type
 makeRestrictionManagerParams(): Promise<void>
 ```
 
-Re-applies the tariff-derived restriction params. Called automatically from `initData`; you only need to invoke it manually if you have already overridden the limiter config and want to reset to the tariff defaults.
+Повторно применяет ограничения, выведенные из тарифа. Вызывается автоматически из `initData`; вызывать вручную нужно только если вы уже переопределили конфигурацию лимитера и хотите сбросить её к значениям тарифа по умолчанию.

--- a/docs/content/docs/2.working-with-the-rest-api/56.helper-currency-manager.md
+++ b/docs/content/docs/2.working-with-the-rest-api/56.helper-currency-manager.md
@@ -1,6 +1,6 @@
 ---
 title: CurrencyManager
-description: 'Currency catalogue cached in memory — base currency, per-currency formatters, and number-to-string formatter.'
+description: 'Каталог валют, кэшируемый в памяти — базовая валюта, форматтеры для каждой валюты и форматтер числа в строку.'
 category: 'Helper'
 navigation.title: CurrencyManager
 links:
@@ -12,9 +12,9 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts
 ---
 
-`CurrencyManager`{lang="ts-type"} caches the result of `crm.currency.base.get` + `crm.currency.list` (and a follow-up batched `crm.currency.get` for per-language formatters). Created when `LoadDataType.Currency` is requested; reachable through [`B24HelperManager.currency`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
+`CurrencyManager`{lang="ts-type"} кэширует результат `crm.currency.base.get` + `crm.currency.list` (и последующий батч `crm.currency.get` для форматтеров по языкам). Создаётся, когда запрошен `LoadDataType.Currency`; доступен через [`B24HelperManager.currency`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions).
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import { useB24Helper, LoadDataType } from '@bitrix24/b24jssdk'
@@ -28,7 +28,7 @@ console.log(currency.currencyList)              // ['USD', 'EUR', 'RUB', ...]
 console.log(currency.format(1234.5, 'USD', 'en')) // '$1,234.50'
 ```
 
-## Getters {#getters}
+## Геттеры {#getters}
 
 ### `baseCurrency` {#basecurrency}
 
@@ -36,7 +36,7 @@ console.log(currency.format(1234.5, 'USD', 'en')) // '$1,234.50'
 get baseCurrency(): string
 ```
 
-Portal's base currency code (`USD`, `RUB`, …).
+Код базовой валюты портала (`USD`, `RUB`, …).
 
 ### `currencyList` {#currencylist}
 
@@ -44,7 +44,7 @@ Portal's base currency code (`USD`, `RUB`, …).
 get currencyList(): string[]
 ```
 
-Array of available currency codes.
+Массив доступных кодов валют.
 
 ### `data` {#data}
 
@@ -52,9 +52,9 @@ Array of available currency codes.
 get data(): { currencyBase: string, currencyList: Map<string, Currency> }
 ```
 
-Internal cache. The `Currency`{lang="ts-type"} value type is documented in [`b24-helper.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts).
+Внутренний кэш. Тип значения `Currency`{lang="ts-type"} описан в [`b24-helper.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts).
 
-## Methods {#methods}
+## Методы {#methods}
 
 ### `getCurrencyFullName` {#getcurrencyfullname}
 
@@ -62,7 +62,7 @@ Internal cache. The `Currency`{lang="ts-type"} value type is documented in [`b24
 getCurrencyFullName(currencyCode: string, langCode?: string): string
 ```
 
-Localised full name (e.g. `Russian Ruble`). Throws `UnhandledMatchError`{lang="ts-type"} for unknown `currencyCode`.
+Локализованное полное название (например, `Russian Ruble`). Выбрасывает `UnhandledMatchError`{lang="ts-type"} для неизвестного `currencyCode`.
 
 ### `getCurrencyLiteral` {#getcurrencyliteral}
 
@@ -70,7 +70,7 @@ Localised full name (e.g. `Russian Ruble`). Throws `UnhandledMatchError`{lang="t
 getCurrencyLiteral(currencyCode: string, langCode?: string): string
 ```
 
-Currency symbol/literal extracted from the format string (e.g. `$`, `₽`).
+Символ/литерал валюты, извлечённый из строки формата (например, `$`, `₽`).
 
 ### `format` {#format}
 
@@ -78,7 +78,7 @@ Currency symbol/literal extracted from the format string (e.g. `$`, `₽`).
 format(value: number, currencyCode: string, langCode: string): string
 ```
 
-Returns the value formatted per the per-language `formatString`, `decimals`, `decPoint`, `thousandsSep` (with the same `THOUSANDS_VARIANT` mapping Bitrix24 uses on the server).
+Возвращает значение, отформатированное по `formatString`, `decimals`, `decPoint`, `thousandsSep` для конкретного языка (с тем же отображением `THOUSANDS_VARIANT`, которое Bitrix24 использует на сервере).
 
 ### `setBaseCurrency` / `setCurrencyList` {#setbasecurrency-setcurrencylist}
 
@@ -87,4 +87,4 @@ setBaseCurrency(currencyBase: string): void
 setCurrencyList(list: CurrencyInit[]): void
 ```
 
-Manual overrides — primarily used internally during `initData`.
+Ручные переопределения — в основном используются внутренне во время `initData`.

--- a/docs/content/docs/2.working-with-the-rest-api/57.helper-options-manager.md
+++ b/docs/content/docs/2.working-with-the-rest-api/57.helper-options-manager.md
@@ -1,6 +1,6 @@
 ---
 title: OptionsManager
-description: 'Typed access to `app.option.get` / `user.option.get`, plus a save() that batches `*.option.set` with an optional Pull notification.'
+description: 'Типизированный доступ к `app.option.get` / `user.option.get`, плюс save(), который батчит `*.option.set` с необязательным Pull-уведомлением.'
 category: 'Helper'
 navigation.title: OptionsManager
 links:
@@ -12,9 +12,9 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts
 ---
 
-`OptionsManager`{lang="ts-type"} is created twice — once for `app.option.get` and once for `user.option.get`. Reachable through [`B24HelperManager.appOptions`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions) and [`B24HelperManager.userOptions`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions). It treats option values as raw strings server-side and converts on read.
+`OptionsManager`{lang="ts-type"} создаётся дважды — один раз для `app.option.get` и один раз для `user.option.get`. Доступен через [`B24HelperManager.appOptions`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions) и [`B24HelperManager.userOptions`](/docs/working-with-the-rest-api/helper/#profileinfo--appinfo--paymentinfo--licenseinfo--currency--appoptions--useroptions). Он хранит значения опций на сервере как сырые строки и конвертирует их при чтении.
 
-## Usage {#usage}
+## Использование {#usage}
 
 ```ts
 import { useB24Helper, LoadDataType } from '@bitrix24/b24jssdk'
@@ -24,49 +24,49 @@ await initB24Helper($b24, [LoadDataType.AppOptions, LoadDataType.UserOptions])
 
 const helper = getB24Helper()
 
-// Read with a default
+// Чтение со значением по умолчанию
 const filters = helper.userOptions.getJsonObject('listFilters', {})
 const itemsPerPage = helper.userOptions.getInteger('itemsPerPage', 20)
 
-// Persist
+// Сохранение
 await helper.appOptions.save(
   { theme: 'dark' },
   { moduleId: 'main', command: 'optionsChanged', params: { theme: 'dark' } }
 )
 ```
 
-## Typed Getters {#typed-getters}
+## Типизированные геттеры {#typed-getters}
 
-| Method | Returns | Default | Notes |
+| Метод | Возвращает | По умолчанию | Примечания |
 |----|----|----|----|
-| `getJsonArray(key, def?)` | `any[]`{lang="ts-type"} | `[]`{lang="ts-type"} | Parses JSON, also accepts JSON objects (returns `Object.values`). |
-| `getJsonObject(key, def?)` | `object`{lang="ts-type"} | `{}`{lang="ts-type"} | Parses JSON, falls back to `def` on failure. |
-| `getFloat(key, def?)` | `number`{lang="ts-type"} | `0.0`{lang="ts-type"} | Uses `Text.toNumber`. |
-| `getInteger(key, def?)` | `number`{lang="ts-type"} | `0`{lang="ts-type"} | Uses `Text.toInteger`. |
+| `getJsonArray(key, def?)` | `any[]`{lang="ts-type"} | `[]`{lang="ts-type"} | Парсит JSON, также принимает JSON-объекты (возвращает `Object.values`). |
+| `getJsonObject(key, def?)` | `object`{lang="ts-type"} | `{}`{lang="ts-type"} | Парсит JSON, при неудаче возвращает `def`. |
+| `getFloat(key, def?)` | `number`{lang="ts-type"} | `0.0`{lang="ts-type"} | Использует `Text.toNumber`. |
+| `getInteger(key, def?)` | `number`{lang="ts-type"} | `0`{lang="ts-type"} | Использует `Text.toInteger`. |
 | `getBoolYN(key, def?)` | `boolean`{lang="ts-type"} | `true`{lang="ts-type"} | `'Y'` → `true`, `'N'` → `false`. |
-| `getBoolNY(key, def?)` | `boolean`{lang="ts-type"} | `false`{lang="ts-type"} | Same conversion as `getBoolYN`, different default. |
-| `getString(key, def?)` | `string`{lang="ts-type"} | `''`{lang="ts-type"} | Calls `.toString()`. |
-| `getDate(key, def?)` | `null \| DateTime`{lang="ts-type"} | `null`{lang="ts-type"} | Uses `Text.toDateTime` (Luxon). |
+| `getBoolNY(key, def?)` | `boolean`{lang="ts-type"} | `false`{lang="ts-type"} | То же преобразование, что и `getBoolYN`, но другое значение по умолчанию. |
+| `getString(key, def?)` | `string`{lang="ts-type"} | `''`{lang="ts-type"} | Вызывает `.toString()`. |
+| `getDate(key, def?)` | `null \| DateTime`{lang="ts-type"} | `null`{lang="ts-type"} | Использует `Text.toDateTime` (Luxon). |
 
-## Static Helpers {#static-helpers}
+## Статические хелперы {#static-helpers}
 
 ```ts-type
 OptionsManager.getSupportTypes(): TypeOption[]
 OptionsManager.prepareArrayList(list: any): any[]
 ```
 
-`TypeOption`{lang="ts-type"} enumerates the supported value shapes (`NotSet / JsonArray / JsonObject / FloatVal / IntegerVal / BoolYN / StringVal`).
+`TypeOption`{lang="ts-type"} перечисляет поддерживаемые формы значений (`NotSet / JsonArray / JsonObject / FloatVal / IntegerVal / BoolYN / StringVal`).
 
-## Cache Methods {#cache-methods}
+## Методы кэша {#cache-methods}
 
 ```ts-type
 get data(): Map<string, any>
 reset(): void
 ```
 
-`data` is the raw key→string map. `reset()` clears the in-memory cache without touching the server.
+`data` — это сырая карта ключ→строка. `reset()` очищает кэш в памяти, не затрагивая сервер.
 
-## Save {#save}
+## Сохранение {#save}
 
 ```ts-type
 save(
@@ -76,22 +76,22 @@ save(
 ): Promise<Result>
 ```
 
-Issues a single batched call:
+Выполняет один батч-вызов:
 
-1. `app.option.set` for `appOptions` / `user.option.set` for `userOptions`, with the supplied `options` payload.
-2. Optionally `pull.application.event.add` so other clients are notified about the change.
+1. `app.option.set` для `appOptions` / `user.option.set` для `userOptions`, с переданным payload `options`.
+2. Необязательно `pull.application.event.add`, чтобы другие клиенты были уведомлены об изменении.
 
-Both calls share `isHaltOnError: true`. Returns the wrapping [`Result`{lang="ts-type"}](/docs/working-with-the-rest-api/core-result/).
+Оба вызова используют `isHaltOnError: true`. Возвращает оборачивающий [`Result`{lang="ts-type"}](/docs/working-with-the-rest-api/core-result/).
 
 ::note
-`save()` does **not** update the local cache. Call `getB24Helper().loadData([LoadDataType.AppOptions])` (or rerun `initB24Helper`) if you need the new state to be visible to subsequent `getX()` reads.
+`save()` **не** обновляет локальный кэш. Вызовите `getB24Helper().loadData([LoadDataType.AppOptions])` (или повторно запустите `initB24Helper`), если нужно, чтобы новое состояние было видно последующим чтениям `getX()`.
 ::
 
-## Encoding Helpers {#encoding-helpers}
+## Хелперы кодирования {#encoding-helpers}
 
 ```ts-type
-encode(value: any): string  // JSON.stringify wrapper
-decode(data: string, defaultValue: any): any  // JSON.parse with logged failure
+encode(value: any): string  // обёртка над JSON.stringify
+decode(data: string, defaultValue: any): any  // JSON.parse с логированием ошибки
 ```
 
-Convenience wrappers around `JSON.stringify` / `JSON.parse` that log parse failures through the manager's logger.
+Удобные обёртки над `JSON.stringify` / `JSON.parse`, которые логируют ошибки парсинга через логгер менеджера.

--- a/docs/i18n/glossary.ru.yml
+++ b/docs/i18n/glossary.ru.yml
@@ -1,6 +1,6 @@
 # Translation glossary EN → RU
 #
-# Last reviewed: 2026-06-02 (Stage 3a merge)
+# Last reviewed: 2026-06-04 (Stage 3c PR-B merge)
 #
 # Используется при переводе docs/content/**/*.md на русский.
 # AI или человек должен следовать этому словарю для консистентности.
@@ -87,6 +87,29 @@ terms:
     ru: событие
   - en: event handler
     ru: обработчик события
+
+  # —— Менеджеры и хелперы (Stage 3c PR-B) ——
+  - en: helper
+    ru: хелпер
+    note: |
+      «helper» в прозе → «хелпер» («through the helper» → «через хелпер»).
+      Имена классов SDK (`B24HelperManager`, `ProfileManager`, `AppManager` и пр.) — НЕ переводить.
+  - en: limiter
+    ru: лимитер
+    note: Компонент SDK (ограничитель частоты запросов). «limiter state» → «состояние лимитера». Сам термин «rate limit» — keep_en (см. раздел «Ограничения и ретраи»).
+  - en: handshake
+    ru: рукопожатие
+    note: OAuth/postMessage handshake → «рукопожатие». «getInitData handshake» → «рукопожатие getInitData».
+  - en: bucket
+    ru: корзина
+    note: В контексте `SelectedCRM` — массив элементов по типу сущности. «bucket» → «корзина».
+  - en: closure
+    ru: замыкание
+    note: JS-замыкание. «closure-based composable» → «composable на основе замыкания».
+  - en: self-hosted
+    ru: self-hosted
+    note: Коробочная версия Bitrix24. Оставляем английский («self-hosted», «self-hosted-портал»). Антоним — «облако» (cloud).
+    keep_en: true
 
   # —— Vue / Nuxt экосистема ——
   - en: composable
@@ -281,7 +304,7 @@ terms:
   - en: bundle
     ru: бандл
 
-  # —— Стандартные обороты docа ——
+  # —— Стандартные обороты doca ——
   - en: Note
     ru: Примечание
   - en: Tip


### PR DESCRIPTION
## Кратко

**Stage 3c · PR-B из 3** — перевод точек входа и менеджеров REST API. **18 файлов** переведены, готово к ревью.

Stage 3c всего:
- **PR-A** — методы вызова (call/list/fetch/batch ×v2/v3 + index + choosing). ✅ смёржен (#21)
- **PR-B (этот)** — точки входа и менеджеры: hook, oauth, frame×8, helper×8 (18 файлов)
- **PR-C** (дальше) — вспомогательное: core, logger, limiters, tools, types, errors, telemetry, pull

## Переведено (18 файлов)

**Точки входа (2):**
| Файл | Назначение |
|---|---|
| `20.hook.md` | `B24Hook` — серверная точка входа через входящий вебхук |
| `40.oauth.md` | `B24OAuth` — точка входа OAuth 2.0 + авто-refresh токена |

**Frame-менеджеры (8):**
| Файл | Назначение |
|---|---|
| `30.frame.md` | `B24Frame` — введение, геттеры менеджеров, конструктор |
| `30.frame-initialize-b24-frame.md` | `initializeB24Frame()` |
| `31.frame-auth.md` | `AuthManager` |
| `31.frame-parent.md` | `ParentManager` — управление родительским окном |
| `31.frame-slider.md` | `SliderManager` |
| `31.frame-dialog.md` | `DialogManager` — selectUser/Users/Access/CRM + типы данных |
| `31.frame-placement.md` | `PlacementManager` |
| `31.frame-options.md` | `OptionsManager` (frame) |

**Helper-менеджеры (8):**
| Файл | Назначение |
|---|---|
| `50.helper.md` | `B24HelperManager` — агрегатор + Pull-клиент |
| `51.helper-use-b24-helper.md` | composable `useB24Helper` |
| `52.helper-profile-manager.md` | `ProfileManager` |
| `53.helper-app-manager.md` | `AppManager` |
| `54.helper-payment-manager.md` | `PaymentManager` |
| `55.helper-license-manager.md` | `LicenseManager` |
| `56.helper-currency-manager.md` | `CurrencyManager` |
| `57.helper-options-manager.md` | `OptionsManager` (helper) |

## Применённые правила (по `docs/i18n/`)

- ✅ Якоря `{#en-anchor}` сохранены везде; ссылки `](#…)` — одна решётка (проверено `grep -E '\]\(##'` — пусто)
- ✅ Имена классов/методов SDK (`B24Hook`, `B24Frame`, `B24OAuth`, `B24HelperManager`, `AuthManager`, `DialogManager`, `TypeB24`, `AjaxResult`, `RefreshTokenError`, `ParamsFactory`, `LoadDataType`, `EnumAppStatus` …), `{lang="ts-type"}`, npm-пакеты, API-методы (`crm.item.list`, `app.info`, `pull.application.event.add`) — нетронуты
- ✅ `console.*`/`logger.*`/`throw new Error`, строки ошибок (`'B24 not initialized'`, `'Webhook requires HTTPS protocol'`, `'B24HelperManager not initialized'` …), runtime-warnings — английские
- ✅ Педагогические комментарии в коде переведены (`// ✅ Серверная переменная окружения`, `// Чтение со значением по умолчанию`); директивы `// @check-ignore:` — нетронуты
- ✅ frontmatter: переведены `title`/`description`/`navigation.title`; `category`/`audited`/`links.iconName`/`links.to` — нетронуты
- ✅ `::caution{title="⚠️ CAUTION: SECURITY"}` → `⚠️ ВНИМАНИЕ: БЕЗОПАСНОСТЬ`; `::warning` «We are still updating…» → «Мы всё ещё дорабатываем эту страницу…»
- ✅ MDC: `::note`/`::warning`/`::caution`/`::accordion`/`:::accordion-item{label}`/`::code-example`/`::callout` — синтаксис нетронут, переведён только видимый текст и `label`/`title`
- ✅ keep_en по глоссарию: `scope`, `rate limit`, `operating limit`, `endpoint`, `runtime`, `payload`, `OAuth`, `composable`, `placement`, `callback`, `middleware`, `access token`/`refresh token`
- ✅ Типографика: «ёлочки», длинное тире —

## Терминология (новое в этом PR)

| EN | RU |
|---|---|
| `B24HelperManager` / sub-managers | без перевода (имена классов SDK) |
| helper | хелпер |
| limiter | лимитер |
| handshake | рукопожатие |
| self-hosted | self-hosted (keep_en) |
| bucket (в SelectedCRM) | корзина |
| closure | замыкание |
| composable | composable (keep_en) |

## Проверка

- `grep -rE '\]\(##'` по каталогу — пусто
- `grep -E '\{#[а-я]'` по 18 файлам — пусто (якоря не переведены)
- Баланс code-fence ` ``` ` — чётный во всех файлах
- Непереведённых служебных заголовков (Overview/Methods/Usage/…) не осталось

## Замечания (gap / для PR-C)

- В каталоге висит непереведённый `60.pull.md` — не входит ни в PR-B, ни в PR-C по исходной разбивке. Предлагаю включить в PR-C (он логически связан с Pull-клиентом, на который ссылаются helper-страницы).
- В `40.oauth.md` ссылка `[`auth.isAdmin`](#getter-auth)` указывает на несуществующий якорь (геттер — `{#auth}`). Это баг EN-оригинала; сохранил как есть (зеркалим), стоит завести issue в upstream и поправить синхронно.