### PR TITLE
Stage 3d: translate examples cookbook (99.examples) — RU mirror now 100%

### DIFF
--- a/docs/content/docs/99.examples/.navigation.yml
+++ b/docs/content/docs/99.examples/.navigation.yml
@@ -1,1 +1,1 @@
-title: Examples
+title: Примеры

--- a/docs/content/docs/99.examples/0.index.md
+++ b/docs/content/docs/99.examples/0.index.md
@@ -1,206 +1,206 @@
 ---
-title: Examples
-description: 'Recipes that pair the SDK with realistic scenarios — CRM analytics, mass messaging, AI assistants, OAuth installs, and more. Each recipe is a single, copy-paste-friendly file.'
-navigation.title: Introduction
+title: Примеры
+description: 'Рецепты, сочетающие SDK с реалистичными сценариями — аналитика CRM, массовые рассылки, AI-ассистенты, установка по OAuth и не только. Каждый рецепт — отдельный файл, удобный для копирования.'
+navigation.title: Введение
 ---
 
-This section collects task-shaped examples of using `@bitrix24/b24jssdk`. Most are runnable TypeScript files that double as **agent skills** — the same source lives under [`skills/b24jssdk-recipes/examples/`](https://github.com/bitrix24/b24jssdk/tree/main/skills/b24jssdk-recipes/examples) and is loaded by AI coding tools (Claude Code, Cursor, Copilot) as authoritative SDK context. Every recipe is type-checked in CI via `pnpm run skills:typecheck`.
+В этом разделе собраны примеры использования `@bitrix24/b24jssdk` в форме задач. Большинство — это запускаемые TypeScript-файлы, которые одновременно служат **скилами для агентов**: тот же исходник лежит в [`skills/b24jssdk-recipes/examples/`](https://github.com/bitrix24/b24jssdk/tree/main/skills/b24jssdk-recipes/examples) и загружается AI-инструментами (Claude Code, Cursor, Copilot) как авторитетный контекст по SDK. Каждый рецепт проходит type-check в CI через `pnpm run skills:typecheck`.
 
-## Cookbook {#cookbook}
+## Сборник рецептов {#cookbook}
 
-Curated entry points — each recipe ships environment variables, an expected output sketch, and a `Limitations` block.
+Отобранные точки входа — каждый рецепт содержит переменные окружения, набросок ожидаемого вывода и блок `Ограничения`.
 
 ::card-group
 
 ::card
 ---
-title: Webhook CLI smoke test
+title: Smoke-тест вебхука в CLI
 to: /docs/examples/webhook-cli-node/
 ---
-Verify a freshly created inbound webhook in 30 lines. Always start here.
+Проверьте только что созданный входящий вебхук за 30 строк. Всегда начинайте отсюда.
 ::
 
 ::card
 ---
-title: Export deals to CSV
+title: Экспорт сделок в CSV
 to: /docs/examples/dashboard-deals-csv/
 ---
-Stream every deal in a date window into a CSV using `actions.v2.fetchList.make`. Memory stays flat regardless of result size.
+Стримит все сделки за период в CSV через `actions.v2.fetchList.make`. Память не растёт независимо от размера результата.
 ::
 
 ::card
 ---
-title: Bulk update deals
+title: Массовое обновление сделок
 to: /docs/examples/bulk-update-deals/
 ---
-Migrate thousands of deals to a new stage using `BatchByChunkV2.make()` with partial-error handling.
+Переносит тысячи сделок на новую стадию через `BatchByChunkV2.make()` с обработкой частичных ошибок.
 ::
 
 ::card
 ---
-title: Frame app skeleton
+title: Скелет frame-приложения
 to: /docs/examples/frame-app-skeleton/
 ---
-A minimum viable Vue 3 iframe app: handshake, parent title, persisted options, slider open/close.
+Минимально жизнеспособное Vue 3 iframe-приложение: рукопожатие, заголовок родителя, сохраняемые опции, открытие/закрытие слайдера.
 ::
 
 ::card
 ---
-title: Subscribe to Pull events
+title: Подписка на события Pull
 to: /docs/examples/pull-subscribe-frame/
 ---
-Live events in a frame app via `useB24Helper` and the Pull client (WebSocket + long-polling).
+События в реальном времени во frame-приложении через `useB24Helper` и Pull-клиент (WebSocket + long-polling).
 ::
 
 ::
 
-## Extended catalogue {#extended-catalogue}
+## Расширенный каталог {#extended-catalogue}
 
-End-to-end TypeScript scripts — run with `tsx` after setting `B24_HOOK` to your incoming webhook URL.
+Сквозные TypeScript-скрипты — запускайте через `tsx`, предварительно задав `B24_HOOK` равным URL вашего входящего вебхука.
 
 ::card-group
 
 ::card
 ---
-title: CRM analytics — sales funnel
+title: Аналитика CRM — воронка продаж
 to: /docs/examples/crm-analytics/
 ---
-Stream all deals via `actions.v2.fetchList.make`, group by stage, print a funnel report.
+Стримит все сделки через `actions.v2.fetchList.make`, группирует по стадиям, печатает отчёт по воронке.
 ::
 
 ::card
 ---
-title: Mass messaging
+title: Массовые рассылки
 to: /docs/examples/mass-messaging/
 ---
-Filter contacts, personalise a template, send IM notifications to assigned managers.
+Фильтрует контакты, персонализирует шаблон, отправляет IM-уведомления ответственным менеджерам.
 ::
 
 ::card
 ---
-title: Task automation on stage transitions
+title: Автоматизация задач при смене стадий
 to: /docs/examples/task-automation/
 ---
-Poll deal stages every 60 s. When a watched transition fires, create a task with deadline and priority.
+Опрашивает стадии сделок каждые 60 с. При отслеживаемом переходе создаёт задачу с дедлайном и приоритетом.
 ::
 
 ::card
 ---
-title: ERP / 1C contact sync
+title: Синхронизация контактов с ERP / 1С
 to: /docs/examples/erp-sync/
 ---
-Two-way contact sync between Bitrix24 and an external ERP. Match by INN (primary) or email (fallback).
+Двусторонняя синхронизация контактов между Bitrix24 и внешней ERP. Сопоставление по ИНН (основное) или email (запасное).
 ::
 
 ::card
 ---
-title: Disk — storages, folders, files
+title: Диск — хранилища, папки, файлы
 to: /docs/examples/disk-files/
 ---
-List storages and folder children, create subfolders, inspect files.
+Список хранилищ и содержимого папок, создание подпапок, просмотр файлов.
 ::
 
 ::card
 ---
-title: Telegram bot for new deals
+title: Telegram-бот для новых сделок
 to: /docs/examples/telegram-bot/
 ---
-Poll new CRM deals every two minutes; notify a Telegram chat with an HTML-formatted card.
+Опрашивает новые сделки CRM каждые две минуты; уведомляет Telegram-чат HTML-карточкой.
 ::
 
 ::card
 ---
-title: Outbound webhook handler
+title: Обработчик исходящих вебхуков
 to: /docs/examples/webhook-handler/
 ---
-Express server that receives Bitrix24 outbound events, fetches details via REST, dispatches by event name.
+Express-сервер, который принимает исходящие события Bitrix24, подгружает детали через REST, маршрутизирует по имени события.
 ::
 
 ::card
 ---
-title: AI assistant — analyse a deal, create a follow-up task
+title: AI-ассистент — анализ сделки, создание задачи
 to: /docs/examples/ai-assistant/
 ---
-Load a deal and its activities, ask GPT-4o for the next-best action, create a task bound to the deal.
+Загружает сделку и её дела, спрашивает у GPT-4o лучшее следующее действие, создаёт задачу, привязанную к сделке.
 ::
 
 ::card
 ---
-title: Web search + LLM with timeline write-back
+title: Веб-поиск + LLM с записью в таймлайн
 to: /docs/examples/web-search-llm/
 ---
-Two-step RAG: ask any web-search provider, run the result through your LLM, post the answer as a CRM timeline comment.
+Двухшаговый RAG: запрос к любому провайдеру веб-поиска, прогон результата через ваш LLM, публикация ответа комментарием в таймлайн CRM.
 ::
 
 ::card
 ---
-title: Error-handling cookbook
+title: Сборник рецептов по обработке ошибок
 to: /docs/examples/error-handling/
 ---
-The four error layers (`SdkError` / `AjaxError` / network / soft) and the `hardErrorCodes` / `softErrorCodes` / `retryOnNetworkError` knobs.
+Четыре слоя ошибок (`SdkError` / `AjaxError` / сетевые / soft) и настройки `hardErrorCodes` / `softErrorCodes` / `retryOnNetworkError`.
 ::
 
 ::card
 ---
-title: Outbound event registration
+title: Регистрация исходящих событий
 to: /docs/examples/event-registration/
 ---
-CLI tool — list, bind, and unbind Bitrix24 outbound webhook events via `event.get` / `event.bind` / `event.unbind`.
+CLI-инструмент — список, привязка и отвязка исходящих событий вебхуков Bitrix24 через `event.get` / `event.bind` / `event.unbind`.
 ::
 
 ::card
 ---
-title: OAuth install handshake
+title: Рукопожатие установки OAuth
 to: /docs/examples/oauth-install/
 ---
-Express server that handles `ONAPPINSTALL` / `ONAPPUPDATE` / `ONAPPUNINSTALL`, persists tokens per portal, builds `B24OAuth` on demand.
+Express-сервер, который обрабатывает `ONAPPINSTALL` / `ONAPPUPDATE` / `ONAPPUNINSTALL`, сохраняет токены по порталам, создаёт `B24OAuth` по требованию.
 ::
 
 ::
 
-## UI showcases {#ui-showcases}
+## UI-витрины {#ui-showcases}
 
-Bitrix24 UI components paired with the SDK — these examples live in the [`b24sdk-examples`](https://github.com/bitrix24/b24sdk-examples) repository.
+UI-компоненты Bitrix24 в связке с SDK — эти примеры живут в репозитории [`b24sdk-examples`](https://github.com/bitrix24/b24sdk-examples).
 
 ::card-group
 
 ::card
 ---
-title: Entity List with Pagination
+title: Список сущностей с пагинацией
 to: /docs/examples/entity-list/
 ---
-Render a paged Bitrix24 entity list using `B24Card`, `B24Table`, `B24Pagination`, and the `callList` action.
+Рендерит постраничный список сущностей Bitrix24 через `B24Card`, `B24Table`, `B24Pagination` и действие `callList`.
 ::
 
 ::card
 ---
-title: App Installation Wizard
+title: Мастер установки приложения
 to: /docs/examples/app-installation-wizard/
 ---
-Build a multi-step install screen that runs scope-bound REST calls and wraps up with a confetti animation.
+Строит многошаговый экран установки, выполняющий REST-вызовы по scope и завершающийся анимацией конфетти.
 ::
 
 ::card
 ---
-title: Node + Hook Company Export
+title: Экспорт компаний на Node + Hook
 to: /docs/examples/node-hook-company-export/
 ---
-Server-side script that exports companies into a CSV file using `B24Hook`, `LoggerFactory`, and `Text.toDateTime`.
+Серверный скрипт, экспортирующий компании в CSV-файл через `B24Hook`, `LoggerFactory` и `Text.toDateTime`.
 ::
 
 ::
 
-## Repository {#repository}
+## Репозиторий {#repository}
 
-All runnable examples live in two places:
+Все запускаемые примеры лежат в двух местах:
 
-- [`skills/b24jssdk-recipes/examples/`](https://github.com/bitrix24/b24jssdk/tree/main/skills/b24jssdk-recipes/examples) — the 12 Extended catalogue recipes as TypeScript scripts, type-checked in CI.
-- [`bitrix24/b24sdk-examples`](https://github.com/bitrix24/b24sdk-examples) — paired UI showcases (Nuxt, React) and the original Node/Hook starter scripts. Notable folders:
-  - `js/02-nuxt-hook` — Nuxt + `B24Hook` quick start
-  - `js/03-nuxt-frame` — Nuxt + `B24Frame` (helper, Pull client, dialogs)
-  - `js/05-node-hook` — pure Node.js + `B24Hook` script
+- [`skills/b24jssdk-recipes/examples/`](https://github.com/bitrix24/b24jssdk/tree/main/skills/b24jssdk-recipes/examples) — 12 рецептов расширенного каталога в виде TypeScript-скриптов, проходящих type-check в CI.
+- [`bitrix24/b24sdk-examples`](https://github.com/bitrix24/b24sdk-examples) — парные UI-витрины (Nuxt, React) и исходные стартовые скрипты Node/Hook. Заметные папки:
+  - `js/02-nuxt-hook` — быстрый старт Nuxt + `B24Hook`
+  - `js/03-nuxt-frame` — Nuxt + `B24Frame` (хелпер, Pull-клиент, диалоги)
+  - `js/05-node-hook` — чистый Node.js + скрипт `B24Hook`
   - `js/04-react-frame` — React + `B24Frame`
 
-## Contributing {#contributing}
+## Как внести вклад {#contributing}
 
-Found a missing recipe? Open an issue in [bitrix24/b24jssdk](https://github.com/bitrix24/b24jssdk/issues). Pull requests against the SDK-native recipes go to this repository (under `skills/b24jssdk-recipes/examples/`); pull requests against the UI showcases go to [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples).
+Не хватает рецепта? Откройте issue в [bitrix24/b24jssdk](https://github.com/bitrix24/b24jssdk/issues). Pull request'ы по SDK-нативным рецептам идут в этот репозиторий (в `skills/b24jssdk-recipes/examples/`); pull request'ы по UI-витринам — в [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples).

--- a/docs/content/docs/99.examples/1.crm-analytics.md
+++ b/docs/content/docs/99.examples/1.crm-analytics.md
@@ -1,35 +1,35 @@
 ---
-title: CRM analytics — sales funnel
-description: 'Stream all deals via actions.v2.fetchList.make, group by stage, print a funnel report (counts, conversion %, avg ticket, win rate).'
-navigation.title: CRM analytics
+title: Аналитика CRM — воронка продаж
+description: 'Стримит все сделки через actions.v2.fetchList.make, группирует по стадиям, печатает отчёт по воронке (количество, конверсия %, средний чек, win rate).'
+navigation.title: Аналитика CRM
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/01-crm-analytics.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Loads every deal on the portal in chunks (no loading all rows into RAM), groups them by stage, and prints a console funnel report: counts, conversion percentages, average ticket, total revenue, win rate.
+Загружает все сделки портала чанками (не грузит все строки в RAM), группирует их по стадиям и печатает в консоль отчёт по воронке: количество, проценты конверсии, средний чек, общую выручку, win rate.
 
-## Stack {#stack}
+## Стек {#stack}
 
-Node.js 18+. No external dependencies.
+Node.js 18+. Без внешних зависимостей.
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 01-crm-analytics.ts
 ```
 
-## Code {#code}
+## Код {#code}
 
 ```ts [01-crm-analytics.ts]
 import {
@@ -41,7 +41,7 @@ import {
   type TypeB24
 } from '@bitrix24/b24jssdk'
 
-// New SDK Logger. See /docs/working-with-the-rest-api/logger/.
+// Новый логгер SDK. См. /docs/working-with-the-rest-api/logger/.
 const logger = Logger.create('CrmAnalytics')
 logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
 
@@ -74,8 +74,8 @@ interface DealRow {
 
 async function loadAllDeals($b24: TypeB24): Promise<DealRow[]> {
   const out: DealRow[] = []
-  // Heartbeat every N items so a long load on a large portal doesn't look
-  // like a hang. Drop on small portals where the runtime is sub-second.
+  // Heartbeat каждые N элементов, чтобы долгая загрузка на большом портале не выглядела
+  // как зависание. Уберите на маленьких порталах, где выполнение занимает доли секунды.
   const progressEvery = 500
   let nextProgressAt = progressEvery
   const startedAt = Date.now()
@@ -152,9 +152,9 @@ main().catch((e: unknown) => {
 })
 ```
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- Multi-funnel portals: stage IDs come prefixed (`C2:WON`). The `baseStage()` helper aggregates them under the base name.
-- `fetchList.make` keeps memory bounded — it streams 50-row chunks internally using a keyset cursor on `idKey`.
-- The action **strips any user-supplied `order`** because keyset pagination requires `idKey ASC` — narrow with `filter` instead.
-- For a more efficient revenue roll-up an `actions.v3.aggregate.make` would issue a single `sum` call, but that action surface is not yet exposed in the SDK.
+- Порталы с несколькими воронками: ID стадий приходят с префиксом (`C2:WON`). Хелпер `baseStage()` агрегирует их под базовым именем.
+- `fetchList.make` держит память ограниченной — внутри он стримит чанки по 50 строк, используя keyset-курсор по `idKey`.
+- Действие **отбрасывает любой пользовательский `order`**, потому что keyset-пагинация требует `idKey ASC` — сужайте через `filter`.
+- Для более эффективного подсчёта выручки `actions.v3.aggregate.make` сделал бы один вызов `sum`, но эта поверхность действий пока не доступна в SDK.

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,10 +1,10 @@
 ---
-title: 'Recipe: Export deals to CSV'
-description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
+title: 'Рецепт: экспорт сделок в CSV'
+description: 'Стримит каждую сделку CRM, подходящую под фильтр по дате, в CSV-файл через вебхук и FetchListV2.'
 audited: 2026-05-05
 category: 'examples'
 navigation:
-  title: Deals → CSV
+  title: Сделки → CSV
 links:
   - label: B24Hook
     iconName: GitHubIcon
@@ -15,25 +15,25 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-## Goal {#goal}
+## Цель {#goal}
 
-Pull every CRM deal closed in a date window from a Bitrix24 portal and write it into a CSV file. Memory stays flat regardless of how many deals match — `FetchListV2.make()` streams pages of 50 records at a time.
+Выгрузить из портала Bitrix24 каждую сделку CRM, закрытую за период, и записать её в CSV-файл. Память не растёт независимо от числа подходящих сделок — `FetchListV2.make()` стримит страницы по 50 записей.
 
-## Stack & Prerequisites {#stack-prerequisites}
+## Стек и предпосылки {#stack-prerequisites}
 
-- Node.js 20+, ESM (`"type": "module"` in `package.json`)
+- Node.js 20+, ESM (`"type": "module"` в `package.json`)
 - `@bitrix24/b24jssdk@^1.0.0`
-- A Bitrix24 inbound webhook URL with the `crm` scope. Set it as `B24_HOOK` in your environment.
+- URL входящего вебхука Bitrix24 со scope `crm`. Задайте его как `B24_HOOK` в окружении.
 
 ```bash
 pnpm add @bitrix24/b24jssdk
 export B24_HOOK="https://your-portal.bitrix24.com/rest/1/xxxxxxxxxxxxxxxx/"
 ```
 
-## Full Example {#full-example}
+## Полный пример {#full-example}
 
 `scripts/deals-to-csv.mjs`:
 
@@ -52,14 +52,14 @@ if (!hookUrl) {
   process.exit(1)
 }
 
-// Closed in the previous calendar month.
+// Закрытые в предыдущем календарном месяце.
 const now = new Date()
 const from = new Date(now.getFullYear(), now.getMonth() - 1, 1)
 const to = new Date(now.getFullYear(), now.getMonth(), 1)
 
 const b24 = B24Hook.fromWebhookUrl(hookUrl, {
-  // Lower per-second pressure than `getDefault()` — good for reporting jobs
-  // that run alongside live user traffic on the same portal.
+  // Меньше нагрузка в секунду, чем у `getDefault()` — хорошо для отчётных задач,
+  // работающих рядом с живым пользовательским трафиком на том же портале.
   restrictionParams: ParamsFactory.getBatchProcessing()
 })
 
@@ -70,7 +70,7 @@ const generator = b24.actions.v2.fetchList.make({
     filter: {
       '>=closedAt': Text.toB24Format(from),
       '<closedAt': Text.toB24Format(to),
-      stageSemanticId: 'S' // closed-won
+      stageSemanticId: 'S' // закрыта-выиграна
     },
     select: ['id', 'title', 'opportunity', 'currencyId', 'closedAt', 'assignedById']
   },
@@ -101,7 +101,7 @@ await writeFile(file, rows.join('\n'), 'utf8')
 console.log(`\nwrote ${count} rows to ${file}`)
 ```
 
-## Run It {#run-it}
+## Запуск {#run-it}
 
 ```bash
 node scripts/deals-to-csv.mjs
@@ -109,23 +109,23 @@ node scripts/deals-to-csv.mjs
 # wrote 4350 rows to deals-2026-04.csv
 ```
 
-## How It Works {#how-it-works}
+## Как это работает {#how-it-works}
 
-- `B24Hook.fromWebhookUrl()` parses the webhook URL and gives you a configured `TypeB24` instance — no `await` initialization needed.
-- `ParamsFactory.getBatchProcessing()` swaps the default rate-limit profile for one tuned for long-running scans, so the script doesn't fight live UI requests for the portal queue.
-- `actions.v2.fetchList.make()` returns an `AsyncGenerator<T[]>`. Each `for await` iteration yields up to `limit` records (default `50`) and uses cursor-based pagination on `idKey` ascending — the SDK takes care of stitching pages together.
-- `Text.toB24Format(date)` converts a JS `Date` to the ISO format Bitrix24 expects in `crm.item.list` filters; passing a raw `Date` would not work.
+- `B24Hook.fromWebhookUrl()` разбирает URL вебхука и даёт готовый экземпляр `TypeB24` — инициализация через `await` не нужна.
+- `ParamsFactory.getBatchProcessing()` меняет профиль rate limit по умолчанию на настроенный для долгих сканов, чтобы скрипт не конкурировал с живыми UI-запросами за очередь портала.
+- `actions.v2.fetchList.make()` возвращает `AsyncGenerator<T[]>`. Каждая итерация `for await` отдаёт до `limit` записей (по умолчанию `50`) и использует курсорную пагинацию по `idKey` по возрастанию — SDK сам сшивает страницы.
+- `Text.toB24Format(date)` преобразует JS-`Date` в ISO-формат, который Bitrix24 ожидает в фильтрах `crm.item.list`; передача сырого `Date` не сработает.
 
-## Limitations {#limitations}
+## Ограничения {#limitations}
 
-- `crm.item.list` returns up to 50 records per page; this is a server-side limit, not an SDK setting.
-- The generator does **not** support a custom `order` parameter — cursor pagination requires sorting by `idKey` ascending. Specifying `order` in `params` triggers a runtime warning and is stripped.
-- `idKey` defaults to `'ID'` (uppercase) for v2 endpoints. CRM item methods return `id` (lowercase), so override it explicitly as in the example.
-- One `B24Hook` instance corresponds to a single user account on the portal. If the deals you need are owned by another user, the webhook must be created by that user (or by an account with cross-user access).
-- For very large windows that exhaust the per-day method-call budget, split the date range into smaller chunks and run them sequentially.
+- `crm.item.list` возвращает до 50 записей на страницу; это серверный лимит, а не настройка SDK.
+- Генератор **не** поддерживает пользовательский параметр `order` — курсорная пагинация требует сортировки по `idKey` по возрастанию. Указание `order` в `params` вызывает runtime-предупреждение и отбрасывается.
+- `idKey` по умолчанию `'ID'` (в верхнем регистре) для v2-endpoint-ов. Методы CRM item возвращают `id` (в нижнем регистре), поэтому переопределяйте его явно, как в примере.
+- Один экземпляр `B24Hook` соответствует одному пользователю портала. Если нужные сделки принадлежат другому пользователю, вебхук должен быть создан этим пользователем (или аккаунтом с межпользовательским доступом).
+- Для очень больших периодов, исчерпывающих дневной бюджет вызовов, разбейте диапазон дат на меньшие части и запускайте их последовательно.
 
-## See also {#see-also}
+## См. также {#see-also}
 
-- [`FetchListV2.make()`](/docs/working-with-the-rest-api/fetch-list-rest-api-ver2/) — full method reference.
-- [Node.js install + `B24Hook`](/docs/getting-started/installation/nodejs/) — webhook-based authentication for server scripts like this one.
-- [Restrictions System](/docs/working-with-the-rest-api/limiters/) — choosing a `restrictionParams` preset.
+- [`FetchListV2.make()`](/docs/working-with-the-rest-api/fetch-list-rest-api-ver2/) — полный справочник метода.
+- [Установка Node.js + `B24Hook`](/docs/getting-started/installation/nodejs/) — аутентификация по вебхуку для серверных скриптов вроде этого.
+- [Система ограничений](/docs/working-with-the-rest-api/limiters/) — выбор пресета `restrictionParams`.

--- a/docs/content/docs/99.examples/10.entity-list.md
+++ b/docs/content/docs/99.examples/10.entity-list.md
@@ -1,29 +1,29 @@
 ---
-title: Entity List with Pagination
-description: 'Render a paged Bitrix24 entity list with B24UI components and the SDK callList action.'
-navigation.title: Entity List
+title: Список сущностей с пагинацией
+description: 'Рендерит постраничный список сущностей Bitrix24 с компонентами B24UI и SDK-действием callList.'
+navigation.title: Список сущностей
 links:
-  - label: example source
+  - label: исходник примера
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24sdk-examples
 ---
 
 ::note
-**Required scopes**: `crm`, `user_brief`.
+**Нужные scope**: `crm`, `user_brief`.
 ::
 
-This recipe assembles a typical "list page" — a card with a sortable table, pagination, and an empty state — using B24UI components and `actions.v2.callList.make()`.
+Этот рецепт собирает типичную «страницу списка» — карточку с сортируемой таблицей, пагинацией и пустым состоянием — используя компоненты B24UI и `actions.v2.callList.make()`.
 
-## Components Used {#components-used}
+## Используемые компоненты {#components-used}
 
-- [`B24Card`](https://bitrix24.github.io/b24ui/docs/components/card/) — page container with header / body / footer.
-- [`B24Table`](https://bitrix24.github.io/b24ui/docs/components/table/) — responsive data table.
-- [`B24Pagination`](https://bitrix24.github.io/b24ui/docs/components/pagination/) — page navigation.
-- [`B24Empty`](https://bitrix24.github.io/b24ui/docs/components/empty/) — empty / error state.
-- [`B24Button`](https://bitrix24.github.io/b24ui/docs/components/button/) — actions.
-- [`B24Skeleton`](https://bitrix24.github.io/b24ui/docs/components/skeleton/) — loading placeholder.
+- [`B24Card`](https://bitrix24.github.io/b24ui/docs/components/card/) — контейнер страницы с header / body / footer.
+- [`B24Table`](https://bitrix24.github.io/b24ui/docs/components/table/) — адаптивная таблица данных.
+- [`B24Pagination`](https://bitrix24.github.io/b24ui/docs/components/pagination/) — навигация по страницам.
+- [`B24Empty`](https://bitrix24.github.io/b24ui/docs/components/empty/) — пустое / ошибочное состояние.
+- [`B24Button`](https://bitrix24.github.io/b24ui/docs/components/button/) — действия.
+- [`B24Skeleton`](https://bitrix24.github.io/b24ui/docs/components/skeleton/) — плейсхолдер загрузки.
 
-## Sketch {#sketch}
+## Набросок {#sketch}
 
 ```ts
 import { initializeB24Frame, EnumCrmEntityTypeId, type B24Frame } from '@bitrix24/b24jssdk'
@@ -60,16 +60,16 @@ async function fetchPage(currentPage: number): Promise<{ items: Company[], total
 async function init() {
   $b24 = await initializeB24Frame()
   const { items, total } = await fetchPage(page)
-  // render <B24Table :items="items" /> and <B24Pagination :total="total" :page-size="pageSize" />
+  // рендер <B24Table :items="items" /> и <B24Pagination :total="total" :page-size="pageSize" />
 }
 
 init().catch(console.error)
 ```
 
 ::caution
-`callList` paginates by sorting on `idKey` ascending. Don't pass a custom `params.order` — it can break pagination by creating gaps. Sort client-side after the data is fetched.
+`callList` пагинирует, сортируя по `idKey` по возрастанию. Не передавайте пользовательский `params.order` — он может сломать пагинацию, создав пропуски. Сортируйте на клиенте после загрузки данных.
 ::
 
-## Full Source {#full-source}
+## Полный исходник {#full-source}
 
-The full Vue + B24UI implementation lives in [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples) under the entity-list demo.
+Полная реализация на Vue + B24UI лежит в [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples) в демо entity-list.

--- a/docs/content/docs/99.examples/10.error-handling.md
+++ b/docs/content/docs/99.examples/10.error-handling.md
@@ -1,51 +1,51 @@
 ---
-title: Error-handling cookbook
-description: 'Demonstrates the four error layers (SdkError / AjaxError / network / soft) and the hardErrorCodes / softErrorCodes / retryOnNetworkError knobs on the restriction manager.'
-navigation.title: Error handling
+title: Сборник рецептов по обработке ошибок
+description: 'Демонстрирует четыре слоя ошибок (SdkError / AjaxError / сетевые / soft) и настройки hardErrorCodes / softErrorCodes / retryOnNetworkError у менеджера ограничений.'
+navigation.title: Обработка ошибок
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/10-error-handling.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Shows the canonical error-handling shape for SDK callers:
+Показывает каноническую форму обработки ошибок для вызывающих SDK:
 
-1. **`SdkError`** — programming bug (e.g. calling a non-v3 method via `actions.v3.*`).
-2. **`AjaxError`** — REST returned an error (`ERROR_NOT_FOUND`, `INVALID_CREDENTIALS`, `EXPIRED_TOKEN`, `QUERY_LIMIT_EXCEEDED`, …).
-3. **Network-level** — `NETWORK_ERROR` / `REQUEST_TIMEOUT`. Critically different for non-idempotent calls.
-4. **Soft errors** — codes you've explicitly opted into surfacing via `softErrorCodes` so the call returns `isSuccess: false` instead of throwing.
+1. **`SdkError`** — программная ошибка (например, вызов не-v3-метода через `actions.v3.*`).
+2. **`AjaxError`** — REST вернул ошибку (`ERROR_NOT_FOUND`, `INVALID_CREDENTIALS`, `EXPIRED_TOKEN`, `QUERY_LIMIT_EXCEEDED`, …).
+3. **Сетевой уровень** — `NETWORK_ERROR` / `REQUEST_TIMEOUT`. Критически отличается для неидемпотентных вызовов.
+4. **Soft-ошибки** — коды, которые вы явно включили в возврат через `softErrorCodes`, чтобы вызов возвращал `isSuccess: false` вместо выброса.
 
-Also covers `setRestrictionManagerParams` with the new knobs:
-- `hardErrorCodes` — extend the SDK's "throw immediately, no retry" list with app-specific codes.
-- `softErrorCodes` — extend the "return as soft error in AjaxResult" list.
-- `retryOnNetworkError: false` — disable network retry for `*.add` / `*.update` / file uploads to avoid duplicates.
+Также охватывает `setRestrictionManagerParams` с новыми настройками:
+- `hardErrorCodes` — расширить список SDK «выбрасывать сразу, без повтора» кодами вашего приложения.
+- `softErrorCodes` — расширить список «возвращать как soft-ошибку в AjaxResult».
+- `retryOnNetworkError: false` — отключить сетевой повтор для `*.add` / `*.update` / загрузок файлов, чтобы избежать дубликатов.
 
-## Stack {#stack}
+## Стек {#stack}
 
-Node.js 18+. No external dependencies.
+Node.js 18+. Без внешних зависимостей.
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 10-error-handling.ts
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/10-error-handling.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/10-error-handling.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- `setRestrictionManagerParams` updates the policy for **all** HTTP clients on this `$b24` instance (both v2 and v3).
-- `hardErrorCodes` and `softErrorCodes` are **additive** — built-in lists (auth/fatal codes) are always hard. You can extend, you can't remove.
-- For non-idempotent calls, prefer wrapping each call in a `try/finally` that restores `retryOnNetworkError: true` afterwards. The recipe shows this pattern.
-- When a network timeout happens for a non-idempotent call, the safe action is **reconcile** (query for the just-created entity by a client-side idempotency tag), not retry.
+- `setRestrictionManagerParams` обновляет политику для **всех** HTTP-клиентов на этом экземпляре `$b24` (и v2, и v3).
+- `hardErrorCodes` и `softErrorCodes` **аддитивны** — встроенные списки (коды авторизации/фатальные) всегда hard. Вы можете расширять, но не удалять.
+- Для неидемпотентных вызовов предпочитайте оборачивать каждый вызов в `try/finally`, восстанавливающий `retryOnNetworkError: true` после. Рецепт показывает этот паттерн.
+- Когда происходит сетевой таймаут для неидемпотентного вызова, безопасное действие — **сверка** (запросить только что созданную сущность по клиентскому тегу идемпотентности), а не повтор.

--- a/docs/content/docs/99.examples/11.event-registration.md
+++ b/docs/content/docs/99.examples/11.event-registration.md
@@ -1,36 +1,36 @@
 ---
-title: Outbound event registration
-description: 'CLI tool — list, bind, and unbind Bitrix24 outbound webhook events via event.get / event.bind / event.unbind. Pairs with the webhook handler recipe.'
-navigation.title: Event registration
+title: Регистрация исходящих событий
+description: 'CLI-инструмент — список, привязка и отвязка исходящих событий вебхуков Bitrix24 через event.get / event.bind / event.unbind. В паре с рецептом обработчика вебхуков.'
+navigation.title: Регистрация событий
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/11-event-registration.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Recipe 7 (webhook handler) assumes events are already bound. This recipe closes that loop:
+Рецепт 7 (обработчик вебхуков) предполагает, что события уже привязаны. Этот рецепт замыкает круг:
 
-- `list` — print all currently bound events on the portal
-- `bind` — register a target URL as a handler for `ONCRMDEALADD`, `ONCRMDEALUPDATE`, `ONCRMDEALDELETE` (idempotent — re-binding the same pair is a no-op)
-- `unbind` — remove those bindings
+- `list` — печатает все привязанные сейчас события на портале
+- `bind` — регистрирует целевой URL как обработчик для `ONCRMDEALADD`, `ONCRMDEALUPDATE`, `ONCRMDEALDELETE` (идемпотентно — повторная привязка той же пары ничего не делает)
+- `unbind` — удаляет эти привязки
 
-Run it once after deploying your handler; re-run on every config change.
+Запустите один раз после деплоя обработчика; перезапускайте при каждом изменении конфигурации.
 
-## Stack {#stack}
+## Стек {#stack}
 
-Node.js 18+. No external dependencies.
+Node.js 18+. Без внешних зависимостей.
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
-export HANDLER_URL='https://your-server.example.com/webhook'   # required for bind/unbind
+export HANDLER_URL='https://your-server.example.com/webhook'   # требуется для bind/unbind
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 11-event-registration.ts list
@@ -38,13 +38,13 @@ npx tsx 11-event-registration.ts bind
 npx tsx 11-event-registration.ts unbind
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/11-event-registration.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/11-event-registration.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- `event.bind` returns the code `ERROR_EVENT_BINDING_EXISTS` if the same (event, handler) pair is already bound — the recipe treats this as success for idempotent runs.
-- `event.unbind` raises if the binding doesn't exist; the recipe logs and continues.
-- The webhook used to call `event.bind` must have the `event` scope (it does for incoming webhooks created from the portal admin UI).
-- For OAuth-installed apps, the equivalent of `event.bind` is binding events at the application level via the dev console or `event.bind` with the app's auth.
+- `event.bind` возвращает код `ERROR_EVENT_BINDING_EXISTS`, если та же пара (событие, обработчик) уже привязана — рецепт считает это успехом для идемпотентных запусков.
+- `event.unbind` выбрасывает исключение, если привязки нет; рецепт логирует и продолжает.
+- Вебхук, используемый для вызова `event.bind`, должен иметь scope `event` (он есть у входящих вебхуков, созданных из админ-UI портала).
+- Для приложений, установленных по OAuth, эквивалент `event.bind` — привязка событий на уровне приложения через dev-консоль или `event.bind` с авторизацией приложения.

--- a/docs/content/docs/99.examples/12.oauth-install.md
+++ b/docs/content/docs/99.examples/12.oauth-install.md
@@ -1,71 +1,71 @@
 ---
-title: OAuth install handshake
-description: 'Express server that handles ONAPPINSTALL / ONAPPUPDATE / ONAPPUNINSTALL events for a Bitrix24 marketplace app, persists tokens per portal, and builds a B24OAuth client on demand with a refresh callback wired to storage.'
-navigation.title: OAuth install
+title: Рукопожатие установки OAuth
+description: 'Express-сервер, который обрабатывает события ONAPPINSTALL / ONAPPUPDATE / ONAPPUNINSTALL для маркетплейс-приложения Bitrix24, сохраняет токены по порталам и создаёт клиент B24OAuth по требованию с callback обновления, подключённым к хранилищу.'
+navigation.title: Установка OAuth
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/12-oauth-install.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-This is the missing piece between "I have a `clientId`/`clientSecret`" and "I have a working `B24OAuth` client". An OAuth-installed Bitrix24 app receives `ONAPPINSTALL`, `ONAPPUPDATE`, and `ONAPPUNINSTALL` events to your configured handler URL. This recipe:
+Это недостающее звено между «у меня есть `clientId`/`clientSecret`» и «у меня есть рабочий клиент `B24OAuth`». Приложение Bitrix24, установленное по OAuth, получает события `ONAPPINSTALL`, `ONAPPUPDATE` и `ONAPPUNINSTALL` на ваш настроенный URL обработчика. Этот рецепт:
 
-1. Receives the install event and **persists the OAuth tokens per portal** (`member_id` as the key).
-2. Exposes `clientForMember(memberId)` — builds a `B24OAuth` instance from stored tokens, attaches a refresh callback so the next refreshed pair is written back to storage automatically.
-3. Removes credentials on uninstall.
-4. Demonstrates a per-portal REST call (`profile`) through the resulting client.
+1. Принимает событие установки и **сохраняет OAuth-токены по порталам** (`member_id` как ключ).
+2. Предоставляет `clientForMember(memberId)` — создаёт экземпляр `B24OAuth` из сохранённых токенов, прикрепляет callback обновления, чтобы следующая обновлённая пара автоматически записывалась обратно в хранилище.
+3. Удаляет учётные данные при удалении.
+4. Демонстрирует REST-вызов по порталу (`profile`) через полученный клиент.
 
-Use this as the scaffold for a multi-tenant backend that serves many Bitrix24 portals from one OAuth app.
+Используйте это как каркас для мультитенантного бэкенда, который обслуживает много порталов Bitrix24 из одного OAuth-приложения.
 
-## Stack {#stack}
+## Стек {#stack}
 
 Node.js 18+, `express`.
 
-## Install {#install}
+## Установка {#install}
 
 ```bash
 pnpm add express
 ```
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
-export PORT=3001                             # default
-export B24_CLIENT_ID='local.abc123'          # from your Bitrix24 dev console
+export PORT=3001                             # по умолчанию
+export B24_CLIENT_ID='local.abc123'          # из вашей dev-консоли Bitrix24
 export B24_CLIENT_SECRET='...'
 ```
 
-In the Bitrix24 dev console:
+В dev-консоли Bitrix24:
 
-- **Install handler URL**: `https://your-server.example.com/install`
-- **Uninstall handler URL**: `https://your-server.example.com/uninstall`
+- **URL обработчика установки**: `https://your-server.example.com/install`
+- **URL обработчика удаления**: `https://your-server.example.com/uninstall`
 
-For local development, expose with `npx ngrok http 3001`.
+Для локальной разработки пробросьте через `npx ngrok http 3001`.
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 12-oauth-install.ts
 ```
 
-Then trigger the handshake by installing the app on a Bitrix24 portal. Verify with:
+Затем запустите рукопожатие, установив приложение на портал Bitrix24. Проверьте через:
 
 ```bash
 curl https://your-server.example.com/portal/<memberId>/profile
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/12-oauth-install.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/12-oauth-install.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- **Persistence is a JSON file** for demo purposes (`.oauth-store.json`). Replace with Postgres / Redis / your real datastore for production.
-- **`application_token`** — Bitrix24 sends this with both install and uninstall events. The recipe stores it but does not verify it on uninstall — in production, compare the value before removing credentials to protect against spoofed uninstall calls.
-- **`setCallbackRefreshAuth`** is wired at every `clientForMember()` call. This ensures the storage always has the latest token pair after the SDK auto-refreshes a 401.
-- **Always return 200** to the install / uninstall endpoints. Non-2xx triggers Bitrix24 retries for 24 hours.
-- For multiple workers serving the same portal, use a transactional store (Postgres `ON CONFLICT UPDATE`) so concurrent refreshes don't lose tokens.
-- For the wider per-portal multi-tenant pattern (cache strategy, lifecycle, revoked installs), this recipe is the foundation — wrap `clientForMember` in an LRU cache keyed by `memberId` for hot portals.
+- **Хранилище — JSON-файл** для демо (`.oauth-store.json`). Для production замените на Postgres / Redis / ваше реальное хранилище.
+- **`application_token`** — Bitrix24 присылает его и с событиями установки, и удаления. Рецепт его сохраняет, но не проверяет при удалении — в production сравнивайте значение перед удалением учётных данных, чтобы защититься от подделанных вызовов удаления.
+- **`setCallbackRefreshAuth`** подключается при каждом вызове `clientForMember()`. Это гарантирует, что в хранилище всегда последняя пара токенов после авто-обновления SDK при 401.
+- **Всегда возвращайте 200** на endpoint-ы установки / удаления. Не-2xx запускает повторы Bitrix24 на 24 часа.
+- Для нескольких воркеров, обслуживающих один портал, используйте транзакционное хранилище (Postgres `ON CONFLICT UPDATE`), чтобы параллельные обновления не теряли токены.
+- Для более широкого мультитенантного паттерна по порталам (стратегия кэша, жизненный цикл, отозванные установки) этот рецепт — основа: оберните `clientForMember` в LRU-кэш по ключу `memberId` для «горячих» порталов.

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -1,10 +1,10 @@
 ---
-title: 'Recipe: Frame app skeleton'
-description: 'Minimum viable Bitrix24 iframe app: init handshake, set title, persist app state, open a slider, close cleanly.'
+title: 'Рецепт: скелет frame-приложения'
+description: 'Минимально жизнеспособное iframe-приложение Bitrix24: рукопожатие init, установка заголовка, сохранение состояния приложения, открытие слайдера, чистое закрытие.'
 audited: 2026-05-29
 category: 'examples'
 navigation:
-  title: Frame app skeleton
+  title: Скелет frame-приложения
 links:
   - label: B24Frame
     iconName: GitHubIcon
@@ -15,24 +15,24 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-## Goal {#goal}
+## Цель {#goal}
 
-A single Vue 3 component that demonstrates the four things every Bitrix24 iframe app needs: initialize the postMessage handshake, set the parent window title, persist a piece of state across reloads via app options, and open another portal page in a slider.
+Один Vue 3-компонент, демонстрирующий четыре вещи, нужные каждому iframe-приложению Bitrix24: инициализировать рукопожатие postMessage, задать заголовок родительского окна, сохранить часть состояния между перезагрузками через опции приложения и открыть другую страницу портала в слайдере.
 
-## Stack & Prerequisites {#stack-prerequisites}
+## Стек и предпосылки {#stack-prerequisites}
 
-- Vue 3 + Vite (or Nuxt 3 with `@bitrix24/b24jssdk-nuxt`)
+- Vue 3 + Vite (или Nuxt 3 с `@bitrix24/b24jssdk-nuxt`)
 - `@bitrix24/b24jssdk@^1.0.0`
-- The page must be served from the URL registered as the placement handler in your Bitrix24 app card. Outside the iframe, `initializeB24Frame()` rejects.
+- Страница должна отдаваться с URL, зарегистрированного как обработчик placement в карточке вашего приложения Bitrix24. Вне iframe `initializeB24Frame()` завершается reject.
 
 ```bash
 pnpm add @bitrix24/b24jssdk
 ```
 
-## Full Example {#full-example}
+## Полный пример {#full-example}
 
 `src/components/AppShell.vue`:
 
@@ -61,11 +61,11 @@ onMounted(async () => {
   }
 
   $b24.parent.setTitle('My Bitrix24 App')
-  // Auto-resize the iframe to fit its content; call again when content height
-  // changes (e.g. after a network response renders).
+  // Авто-ресайз iframe под содержимое; вызывайте снова, когда высота содержимого
+  // меняется (например, после рендера ответа сети).
   await $b24.parent.resizeWindowAuto()
 
-  // Read persisted preferences. Returns `null` if nothing was set yet.
+  // Чтение сохранённых настроек. Возвращает `null`, если ничего ещё не задано.
   const stored = $b24.options.appGet('theme') as 'light' | 'dark' | null
   if (stored) userTheme.value = stored
 
@@ -81,7 +81,7 @@ onBeforeUnmount(() => {
 
 async function setTheme(value: 'light' | 'dark') {
   userTheme.value = value
-  // App-scoped option: persisted on the portal under the app, not the user.
+  // Опция уровня приложения: хранится на портале под приложением, не под пользователем.
   await $b24?.options.appSet('theme', value)
 }
 
@@ -129,43 +129,43 @@ import AppShell from './components/AppShell.vue'
 createApp(AppShell).mount('#app')
 ```
 
-## Run It {#run-it}
+## Запуск {#run-it}
 
 ```bash
-# 1. Local dev server (Vite)
+# 1. Локальный dev-сервер (Vite)
 pnpm dev
-# → http://localhost:5173/ — running this URL directly will reject:
-#   initializeB24Frame() needs a parent Bitrix24 window.
+# → http://localhost:5173/ — запуск этого URL напрямую завершится reject:
+#   initializeB24Frame() нужно родительское окно Bitrix24.
 
-# 2. Expose the dev server (ngrok / cloudflared / your tunnel of choice)
+# 2. Пробросьте dev-сервер (ngrok / cloudflared / ваш туннель)
 ngrok http 5173
-# → grab the https URL.
+# → возьмите https-URL.
 
-# 3. In Bitrix24: Applications → Developer resources → Local app →
-#    point the placement handler URL at the tunnel URL and Save.
+# 3. В Bitrix24: Приложения → Ресурсы разработчика → Локальное приложение →
+#    укажите URL обработчика placement равным URL туннеля и сохраните.
 
-# 4. Open the placement inside Bitrix24.
+# 4. Откройте placement внутри Bitrix24.
 ```
 
-Once the iframe loads, you'll see: the parent window title becomes "My Bitrix24 App", the iframe resizes to its content, and the body shows `Hello from <your-portal>.bitrix24.com` plus the two buttons. Toggling the theme persists across reloads (the value lives on the portal under the app, not in `localStorage`). Clicking "Open deals in slider" opens `/crm/deal/list/` of the same portal in a Bitrix24-styled slider.
+После загрузки iframe вы увидите: заголовок родительского окна станет «My Bitrix24 App», iframe подстроится под содержимое, а в теле появится `Hello from <your-portal>.bitrix24.com` и две кнопки. Переключение темы сохраняется между перезагрузками (значение живёт на портале под приложением, а не в `localStorage`). Клик по «Open deals in slider» открывает `/crm/deal/list/` того же портала в слайдере в стиле Bitrix24.
 
-## How It Works {#how-it-works}
+## Как это работает {#how-it-works}
 
-- `initializeB24Frame()` is the only correct way to construct `B24Frame`. It deduplicates concurrent calls, parses portal handshake parameters from `window.name`, and waits for the parent window to acknowledge the auth payload.
-- `parent.setTitle()` and `parent.resizeWindowAuto()` reach across the iframe boundary via `postMessage`. Both are idempotent — call them whenever your layout changes.
-- `options.appGet()` is synchronous because the values are loaded once at handshake time. `options.appSet()` is asynchronous because it round-trips to the server.
-- `slider.openPath(url, width)` accepts a `URL` instance (not a string) and returns a `Promise<StatusClose>` that resolves when the user closes the slider. The portal CSP only allows opening URLs on the same portal domain.
+- `initializeB24Frame()` — единственный правильный способ создать `B24Frame`. Он устраняет дублирование параллельных вызовов, разбирает параметры рукопожатия портала из `window.name` и ждёт, пока родительское окно подтвердит payload авторизации.
+- `parent.setTitle()` и `parent.resizeWindowAuto()` пересекают границу iframe через `postMessage`. Оба идемпотентны — вызывайте их всякий раз при изменении вёрстки.
+- `options.appGet()` синхронный, потому что значения загружаются один раз во время рукопожатия. `options.appSet()` асинхронный, потому что делает round-trip к серверу.
+- `slider.openPath(url, width)` принимает экземпляр `URL` (не строку) и возвращает `Promise<StatusClose>`, который разрешается, когда пользователь закрывает слайдер. CSP портала разрешает открывать URL только на домене того же портала.
 
-## Limitations {#limitations}
+## Ограничения {#limitations}
 
-- The component must mount **inside** the Bitrix24 iframe; running it standalone (e.g. in Storybook) fails immediately because the parent window is missing. Guard for `window.parent === window` if you need a graceful fallback.
-- `$b24.options.appSet()` writes one option at a time. Batching multiple writes inside a single render is fine (the SDK serializes them), but each call is a network round-trip.
-- `parent.closeApplication()` only closes the app slider when the placement supports closing. Embedded placements (sidebar widgets) ignore the request.
-- App-scoped options are visible to every user of the app on the portal. Use `userGet` / `userSet` for per-user preferences.
+- Компонент должен монтироваться **внутри** iframe Bitrix24; запуск отдельно (например, в Storybook) сразу падает, потому что родительского окна нет. Защищайтесь проверкой `window.parent === window`, если нужен мягкий фолбэк.
+- `$b24.options.appSet()` записывает по одной опции за раз. Несколько записей в одном рендере — нормально (SDK их сериализует), но каждый вызов — это сетевой round-trip.
+- `parent.closeApplication()` закрывает слайдер приложения только когда placement поддерживает закрытие. Встроенные placement (виджеты сайдбара) игнорируют запрос.
+- Опции уровня приложения видны каждому пользователю приложения на портале. Для пользовательских настроек используйте `userGet` / `userSet`.
 
-## See also {#see-also}
+## См. также {#see-also}
 
 - [`initializeB24Frame()`](/docs/working-with-the-rest-api/frame-initialize-b24-frame/)
-- [`B24Frame.parent`](/docs/working-with-the-rest-api/frame-parent/) — title, resize, close, IM helpers.
+- [`B24Frame.parent`](/docs/working-with-the-rest-api/frame-parent/) — заголовок, ресайз, закрытие, IM-хелперы.
 - [`B24Frame.slider`](/docs/working-with-the-rest-api/frame-slider/)
-- [`B24Frame.options`](/docs/working-with-the-rest-api/frame-options/) — app and user option storage.
+- [`B24Frame.options`](/docs/working-with-the-rest-api/frame-options/) — хранилище опций приложения и пользователя.

--- a/docs/content/docs/99.examples/2.mass-messaging.md
+++ b/docs/content/docs/99.examples/2.mass-messaging.md
@@ -1,40 +1,40 @@
 ---
-title: Mass messaging
-description: 'Filter contacts in CRM, personalise a template, send IM notifications to assigned managers.'
-navigation.title: Mass messaging
+title: Массовые рассылки
+description: 'Фильтрует контакты в CRM, персонализирует шаблон, отправляет IM-уведомления ответственным менеджерам.'
+navigation.title: Массовые рассылки
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/02-mass-messaging.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Reads up to 100 contacts that match a filter, builds a personal greeting from a template, and sends each one as a system IM notification (`im.notify`) to the contact's assigned manager. Pauses between sends to respect rate limits.
+Читает до 100 контактов, подходящих под фильтр, строит персональное приветствие из шаблона и отправляет каждое как системное IM-уведомление (`im.notify`) ответственному менеджеру контакта. Делает паузы между отправками, чтобы соблюдать rate limit.
 
-## Stack {#stack}
+## Стек {#stack}
 
-Node.js 18+. No external dependencies.
+Node.js 18+. Без внешних зависимостей.
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 02-mass-messaging.ts
 ```
 
-## Source {#source}
+## Исходник {#source}
 
-The full file is published in the skill at [`skills/b24jssdk-recipes/examples/02-mass-messaging.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/02-mass-messaging.ts).
+Полный файл опубликован в скиле: [`skills/b24jssdk-recipes/examples/02-mass-messaging.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/02-mass-messaging.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- `im.notify` requires the IM module to be enabled on the portal.
-- The example sends to the **assigned manager** of each contact, not to the contact directly. To DM the contact instead, use `imopenlines.crm.message.add` (Open Channels).
-- For thousands of contacts use `actions.v2.fetchList.make` and split the sends across `actions.v2.batchByChunk.make` instead of a sleep loop.
+- `im.notify` требует включённого модуля IM на портале.
+- Пример отправляет **ответственному менеджеру** каждого контакта, а не самому контакту. Чтобы написать напрямую контакту, используйте `imopenlines.crm.message.add` (Открытые линии).
+- Для тысяч контактов используйте `actions.v2.fetchList.make` и распределяйте отправки через `actions.v2.batchByChunk.make` вместо цикла со sleep.

--- a/docs/content/docs/99.examples/20.app-installation-wizard.md
+++ b/docs/content/docs/99.examples/20.app-installation-wizard.md
@@ -1,28 +1,28 @@
 ---
-title: App Installation Wizard
-description: 'Multi-step install flow that creates user fields, registers placements, finalises the installation, and celebrates with confetti.'
-navigation.title: Installation Wizard
+title: Мастер установки приложения
+description: 'Многошаговый процесс установки, который создаёт пользовательские поля, регистрирует placement-ы, финализирует установку и празднует конфетти.'
+navigation.title: Мастер установки
 links:
-  - label: example source
+  - label: исходник примера
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24sdk-examples
 ---
 
 ::note
-**Required scopes** depend on what the wizard does — at minimum `crm`, `user_brief`, `userfieldconfig`, `placement`.
+**Нужные scope** зависят от того, что делает мастер — как минимум `crm`, `user_brief`, `userfieldconfig`, `placement`.
 ::
 
-A Bitrix24 application is "installing" between when the user accepts the install dialog and when the app calls `installFinish()`. During that window you can provision custom fields, register placements, seed app options — anything the app needs before it greets the user. This recipe shows the structure of such a flow.
+Приложение Bitrix24 находится в состоянии «установки» между моментом, когда пользователь принимает диалог установки, и моментом, когда приложение вызывает `installFinish()`. В этом окне вы можете создать пользовательские поля, зарегистрировать placement-ы, засеять опции приложения — всё, что нужно приложению до приветствия пользователя. Этот рецепт показывает структуру такого процесса.
 
-## Components Used {#components-used}
+## Используемые компоненты {#components-used}
 
-- [`B24Button`](https://bitrix24.github.io/b24ui/docs/components/button/) — start / retry / finish actions.
-- [`B24Progress`](https://bitrix24.github.io/b24ui/docs/components/progress/) — visual progress bar.
-- [`ProseH1`](https://bitrix24.github.io/b24ui/docs/typography/headers-and-text/#heading-1) / [`ProseP`](https://bitrix24.github.io/b24ui/docs/typography/headers-and-text/#paragraph) — title and status text.
-- [`ProsePre`](https://bitrix24.github.io/b24ui/docs/typography/code/#inline-code) — debug / log output.
-- [`useConfetti`](https://bitrix24.github.io/b24ui/docs/composables/use-confetti/) — closing animation.
+- [`B24Button`](https://bitrix24.github.io/b24ui/docs/components/button/) — действия начать / повторить / завершить.
+- [`B24Progress`](https://bitrix24.github.io/b24ui/docs/components/progress/) — визуальный прогресс-бар.
+- [`ProseH1`](https://bitrix24.github.io/b24ui/docs/typography/headers-and-text/#heading-1) / [`ProseP`](https://bitrix24.github.io/b24ui/docs/typography/headers-and-text/#paragraph) — заголовок и текст статуса.
+- [`ProsePre`](https://bitrix24.github.io/b24ui/docs/typography/code/#inline-code) — отладочный / лог-вывод.
+- [`useConfetti`](https://bitrix24.github.io/b24ui/docs/composables/use-confetti/) — финальная анимация.
 
-## Flow {#flow}
+## Процесс {#flow}
 
 ```ts
 import { initializeB24Frame, type B24Frame } from '@bitrix24/b24jssdk'
@@ -30,7 +30,7 @@ import { initializeB24Frame, type B24Frame } from '@bitrix24/b24jssdk'
 let $b24: B24Frame
 
 async function provision(): Promise<void> {
-  // Wrap related steps in a batch so they hit a single round-trip
+  // Оборачиваем связанные шаги в батч, чтобы они шли одним round-trip
   await $b24.actions.v2.batch.make({
     calls: {
       addUserField: {
@@ -56,20 +56,20 @@ async function run() {
   $b24 = await initializeB24Frame()
 
   if (!$b24.isInstallMode) {
-    // Already installed — render the regular UI
+    // Уже установлено — рендерим обычный UI
     return
   }
 
   await provision()
   await $b24.installFinish()
-  // celebrate with useConfetti() ...
+  // празднуем через useConfetti() ...
 }
 
 run().catch(console.error)
 ```
 
-`installFinish()` throws `Error('Application was previously installed. You cannot call installFinish')` when the application is no longer in install mode — guard with `isInstallMode`.
+`installFinish()` выбрасывает `Error('Application was previously installed. You cannot call installFinish')`, когда приложение больше не в режиме установки — защищайтесь проверкой `isInstallMode`.
 
-## Full Source {#full-source}
+## Полный исходник {#full-source}
 
-See [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples) for the complete wizard with progress UI, retry, and confetti.
+Полный мастер с UI прогресса, повтором и конфетти см. в [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples).

--- a/docs/content/docs/99.examples/3.task-automation.md
+++ b/docs/content/docs/99.examples/3.task-automation.md
@@ -1,40 +1,40 @@
 ---
-title: Task automation on stage transitions
-description: 'Poll deal stages every 60 s. When a watched transition fires, create a task with description, deadline and priority.'
-navigation.title: Task automation
+title: Автоматизация задач при смене стадий
+description: 'Опрашивает стадии сделок каждые 60 с. При отслеживаемом переходе создаёт задачу с описанием, дедлайном и приоритетом.'
+navigation.title: Автоматизация задач
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/03-task-automation.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Loads open deals (excluding `WON`/`LOSE`) every minute, compares each stage with the previously seen value, and on each watched transition (`EXECUTING`, `PREPAYMENT_INVOICE`, `FINAL_INVOICE` by default) creates a task bound to the deal via `UF_CRM_TASK`.
+Каждую минуту загружает открытые сделки (исключая `WON`/`LOSE`), сравнивает каждую стадию с предыдущим значением и при каждом отслеживаемом переходе (`EXECUTING`, `PREPAYMENT_INVOICE`, `FINAL_INVOICE` по умолчанию) создаёт задачу, привязанную к сделке через `UF_CRM_TASK`.
 
-## Stack {#stack}
+## Стек {#stack}
 
-Node.js 18+. No external dependencies.
+Node.js 18+. Без внешних зависимостей.
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 03-task-automation.ts
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/03-task-automation.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/03-task-automation.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- State (`dealStages`) is held in memory. Restart loses it by design — for production persist to disk or Redis.
-- Polling is wasteful at scale; the Pull-driven variant (subscribe to `'crm'` events) is on the suggestion list.
-- Multi-funnel portals: the recipe uses a `baseStage()` helper to match `C<n>:EXECUTING`, etc.
+- Состояние (`dealStages`) хранится в памяти. Перезапуск теряет его by design — для production сохраняйте на диск или в Redis.
+- Поллинг расточителен на масштабе; вариант на Pull (подписка на события `'crm'`) есть в списке предложений.
+- Порталы с несколькими воронками: рецепт использует хелпер `baseStage()` для сопоставления `C<n>:EXECUTING` и т.п.

--- a/docs/content/docs/99.examples/3.webhook-cli-node.md
+++ b/docs/content/docs/99.examples/3.webhook-cli-node.md
@@ -1,10 +1,10 @@
 ---
-title: 'Recipe: Webhook CLI smoke test'
-description: 'A 30-line Node script that authenticates against a Bitrix24 portal via inbound webhook and prints the calling user — useful as the first thing you run after creating a webhook.'
+title: 'Рецепт: smoke-тест вебхука в CLI'
+description: 'Node-скрипт на 30 строк, который аутентифицируется на портале Bitrix24 через входящий вебхук и печатает вызывающего пользователя — полезно как первое, что вы запускаете после создания вебхука.'
 audited: 2026-05-05
 category: 'examples'
 navigation:
-  title: Webhook CLI
+  title: Вебхук CLI
 links:
   - label: B24Hook
     iconName: GitHubIcon
@@ -15,25 +15,25 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-## Goal {#goal}
+## Цель {#goal}
 
-Verify that a freshly minted Bitrix24 inbound webhook is reachable, authenticated, and authorized for the scopes you expect — before you wire it into anything bigger. The script calls `profile` and `app.info`, prints the answers, and exits non-zero on any error.
+Убедиться, что только что созданный входящий вебхук Bitrix24 доступен, аутентифицирован и авторизован на ожидаемые scope — прежде чем встраивать его во что-то большее. Скрипт вызывает `profile` и `app.info`, печатает ответы и завершается с ненулевым кодом при любой ошибке.
 
-## Stack & Prerequisites {#stack-prerequisites}
+## Стек и предпосылки {#stack-prerequisites}
 
 - Node.js 20+, ESM
 - `@bitrix24/b24jssdk@^1.0.0`
-- A webhook URL with at least the default scope. Set it as `B24_HOOK`.
+- URL вебхука хотя бы с дефолтным scope. Задайте его как `B24_HOOK`.
 
 ```bash
 pnpm add @bitrix24/b24jssdk
 export B24_HOOK="https://your-portal.bitrix24.com/rest/1/xxxxxxxxxxxxxxxx/"
 ```
 
-## Full Example {#full-example}
+## Полный пример {#full-example}
 
 `scripts/b24-ping.mjs`:
 
@@ -71,7 +71,7 @@ catch (error) {
 }
 ```
 
-## Run It {#run-it}
+## Запуск {#run-it}
 
 ```bash
 node scripts/b24-ping.mjs
@@ -81,22 +81,22 @@ node scripts/b24-ping.mjs
 # webhook is alive
 ```
 
-A copy-pasted-with-typo webhook URL fails with a 401 wrapped in `SdkError` and the script exits with code `1`. A network hiccup is retried automatically by the built-in `RateLimiter` (`maxRetries` defaults to `3`, configurable via `restrictionParams.maxRetries` — see [Restrictions System](/docs/working-with-the-rest-api/limiters/)) before the failure is surfaced.
+Скопированный с опечаткой URL вебхука падает с 401, обёрнутым в `SdkError`, и скрипт завершается с кодом `1`. Сетевой сбой автоматически повторяется встроенным `RateLimiter` (`maxRetries` по умолчанию `3`, настраивается через `restrictionParams.maxRetries` — см. [Система ограничений](/docs/working-with-the-rest-api/limiters/)) до того, как ошибка всплывёт.
 
-## How It Works {#how-it-works}
+## Как это работает {#how-it-works}
 
-- `B24Hook.fromWebhookUrl()` validates the URL shape and pulls the user id, secret token, and portal hostname out of the path. Anything that doesn't look like `https://<host>/rest/<userId>/<token>/` throws synchronously — typo-resistant.
-- `actions.v2.call.make({ method })` is the modern single-method call. It returns `Promise<AjaxResult>`; `.getData().result` is whatever Bitrix24 placed under `result` for that method.
-- Errors come back as `SdkError` with the underlying axios error attached on `cause`. Catching the class lets you distinguish SDK errors from caller bugs.
+- `B24Hook.fromWebhookUrl()` валидирует форму URL и извлекает id пользователя, секретный токен и хост портала из пути. Всё, что не похоже на `https://<host>/rest/<userId>/<token>/`, выбрасывает синхронно — устойчиво к опечаткам.
+- `actions.v2.call.make({ method })` — современный вызов одного метода. Возвращает `Promise<AjaxResult>`; `.getData().result` — то, что Bitrix24 поместил под `result` для этого метода.
+- Ошибки возвращаются как `SdkError` с нижележащей ошибкой axios в `cause`. Перехват класса позволяет отличить ошибки SDK от багов вызывающего кода.
 
-## Limitations {#limitations}
+## Ограничения {#limitations}
 
-- Inbound webhooks have a hard rate cap (2 RPS per user per portal at the time of writing). For more than a smoke test, configure `restrictionParams` — see the dashboard recipe.
-- The `profile` method returns the user the webhook was created **under**, not whoever runs the script. There is no impersonation.
-- This recipe deliberately avoids `try { … } finally { b24.destroy() }` — `B24Hook` has no destroy step. `B24Frame` does; that's a separate code path.
+- У входящих вебхуков жёсткий лимит частоты (2 RPS на пользователя на портал на момент написания). Для чего-то большего, чем smoke-тест, настройте `restrictionParams` — см. рецепт с дашбордом.
+- Метод `profile` возвращает пользователя, **под которым** создан вебхук, а не того, кто запускает скрипт. Имперсонации нет.
+- Этот рецепт намеренно избегает `try { … } finally { b24.destroy() }` — у `B24Hook` нет шага destroy. У `B24Frame` есть; это отдельный путь кода.
 
-## See also {#see-also}
+## См. также {#see-also}
 
-- [Recipe: Export deals to CSV](/docs/examples/dashboard-deals-csv/) — same auth, real workload.
-- [Recipe: Bulk update deals](/docs/examples/bulk-update-deals/) — same auth, write-heavy workload.
-- [`CallV2.make()`](/docs/working-with-the-rest-api/call-rest-api-ver2/) — full method reference.
+- [Рецепт: экспорт сделок в CSV](/docs/examples/dashboard-deals-csv/) — та же авторизация, реальная нагрузка.
+- [Рецепт: массовое обновление сделок](/docs/examples/bulk-update-deals/) — та же авторизация, нагрузка на запись.
+- [`CallV2.make()`](/docs/working-with-the-rest-api/call-rest-api-ver2/) — полный справочник метода.

--- a/docs/content/docs/99.examples/30.node-hook-company-export.md
+++ b/docs/content/docs/99.examples/30.node-hook-company-export.md
@@ -1,23 +1,23 @@
 ---
-title: Node + Hook Company Export
-description: 'Export Bitrix24 companies into a CSV file from a pure Node.js script using B24Hook.'
-navigation.title: Node + Hook Export
+title: Экспорт компаний на Node + Hook
+description: 'Экспорт компаний Bitrix24 в CSV-файл из чистого Node.js-скрипта через B24Hook.'
+navigation.title: Экспорт Node + Hook
 links:
-  - label: example source
+  - label: исходник примера
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24sdk-examples/tree/main/js/05-node-hook
 ---
 
-A typical batch / cron-style job: export companies into a CSV with one webhook. Stays under the rate limits and uses [`fetchList`](/docs/working-with-the-rest-api/fetch-list-rest-api-ver2/) so memory stays flat regardless of dataset size.
+Типичная batch / cron-задача: экспорт компаний в CSV одним вебхуком. Не превышает лимиты частоты и использует [`fetchList`](/docs/working-with-the-rest-api/fetch-list-rest-api-ver2/), поэтому память не растёт независимо от размера набора данных.
 
-## Project Layout {#project-layout}
+## Структура проекта {#project-layout}
 
 ```
 my-export-job/
 ├── dist/
 ├── src/
 │   └── process-company-list.ts
-├── out/                            # generated *.csv files
+├── out/                            # сгенерированные *.csv файлы
 ├── .env.local                      # B24_HOOK=...
 ├── package.json
 └── tsconfig.json
@@ -105,14 +105,14 @@ main().catch((error) => {
 })
 ```
 
-## Why `fetchList`? {#why-fetchlist}
+## Почему `fetchList`? {#why-fetchlist}
 
-- Memory-flat: each `for await` iteration yields a 50-item chunk, so a 50 000-row dataset never materialises in RAM.
-- Built-in pagination: don't roll your own `start: nextStart` loop.
-- Gracefully handles the SDK rate / operating limiters between pages.
+- Память не растёт: каждая итерация `for await` отдаёт чанк из 50 элементов, поэтому набор в 50 000 строк никогда не материализуется в RAM.
+- Встроенная пагинация: не пишите свой цикл `start: nextStart`.
+- Аккуратно обрабатывает rate / operating лимитеры SDK между страницами.
 
-For full-blown bulk operations (delete-then-create, bulk imports), pair the export with [`actions.v2.batchByChunk`](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/).
+Для полноценных массовых операций (удалить-затем-создать, массовые импорты) сочетайте экспорт с [`actions.v2.batchByChunk`](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/).
 
-## Full Source {#full-source}
+## Полный исходник {#full-source}
 
 [bitrix24/b24sdk-examples → js/05-node-hook](https://github.com/bitrix24/b24sdk-examples/tree/main/js/05-node-hook).

--- a/docs/content/docs/99.examples/4.bulk-update-deals.md
+++ b/docs/content/docs/99.examples/4.bulk-update-deals.md
@@ -1,10 +1,10 @@
 ---
-title: 'Recipe: Bulk update deals'
-description: 'Migrate thousands of CRM deals to a new stage using BatchByChunkV2 — automatic chunking, partial-error handling, and a single progress line.'
+title: 'Рецепт: массовое обновление сделок'
+description: 'Переносит тысячи сделок CRM на новую стадию через BatchByChunkV2 — автоматическое разбиение на чанки, обработка частичных ошибок и одна строка прогресса.'
 audited: 2026-05-05
 category: 'examples'
 navigation:
-  title: Bulk update
+  title: Массовое обновление
 links:
   - label: BatchByChunkV2
     iconName: GitHubIcon
@@ -15,19 +15,19 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-## Goal {#goal}
+## Цель {#goal}
 
-Read a CSV mapping of `dealId,newStageId` and apply the stage change to every row. Could be hundreds of deals or tens of thousands — `BatchByChunkV2.make()` chunks the calls into 50-per-batch blocks server-side, no manual paging.
+Прочитать CSV-сопоставление `dealId,newStageId` и применить смену стадии к каждой строке. Может быть сотни сделок или десятки тысяч — `BatchByChunkV2.make()` разбивает вызовы на блоки по 50 на батч на стороне сервера, без ручной пагинации.
 
-## Stack & Prerequisites {#stack-prerequisites}
+## Стек и предпосылки {#stack-prerequisites}
 
 - Node.js 20+, ESM
 - `@bitrix24/b24jssdk@^1.0.0`
-- A webhook with the `crm` scope, set as `B24_HOOK`.
-- A CSV file `migrations.csv`:
+- Вебхук со scope `crm`, заданный как `B24_HOOK`.
+- CSV-файл `migrations.csv`:
 
   ```csv
   dealId,newStageId
@@ -41,7 +41,7 @@ pnpm add @bitrix24/b24jssdk
 export B24_HOOK="https://your-portal.bitrix24.com/rest/1/xxxxxxxxxxxxxxxx/"
 ```
 
-## Full Example {#full-example}
+## Полный пример {#full-example}
 
 `scripts/migrate-deals.mjs`:
 
@@ -62,7 +62,7 @@ if (!hookUrl) {
 const csv = await readFile(process.argv[2] ?? 'migrations.csv', 'utf8')
 const rows = csv
   .split(/\r?\n/)
-  .slice(1) // header
+  .slice(1) // заголовок
   .filter(Boolean)
   .map((line) => {
     const [dealId, newStageId] = line.split(',')
@@ -103,7 +103,7 @@ if (!response.isSuccess) {
 console.log(`updated: ${response.getData()?.length ?? 0} of ${rows.length}`)
 ```
 
-## Run It {#run-it}
+## Запуск {#run-it}
 
 ```bash
 node scripts/migrate-deals.mjs migrations.csv
@@ -111,24 +111,24 @@ node scripts/migrate-deals.mjs migrations.csv
 # updated: 3450 of 3450
 ```
 
-If a few rows fail (deleted deal, missing scope, invalid stage), `isHaltOnError: false` lets the rest of the batch finish and the script exits with code `1` after listing the failures.
+Если несколько строк не пройдут (удалённая сделка, отсутствующий scope, неверная стадия), `isHaltOnError: false` позволяет остальной части батча завершиться, и скрипт выходит с кодом `1`, перечислив сбои.
 
-## How It Works {#how-it-works}
+## Как это работает {#how-it-works}
 
-- `BatchByChunkV2.make({ calls })` accepts an arbitrary number of commands and slices them internally into batches of 50, the per-request hard limit. Output order matches input order.
-- `Result.isSuccess` flips to `false` if any chunk had an error. `getErrorMessages()` returns one message per failed call. Successful calls are still in `getData()` — partial progress is preserved.
-- `ParamsFactory.getBatchProcessing()` raises the operating-time threshold and lowers the request rate, which keeps the portal queue responsive while a long migration runs alongside live UI traffic.
-- Naming the request via `options.requestId` makes it easy to filter portal-side logs and to deduplicate accidental re-runs.
+- `BatchByChunkV2.make({ calls })` принимает произвольное число команд и нарезает их внутри на батчи по 50 — жёсткий лимит на запрос. Порядок вывода совпадает с порядком ввода.
+- `Result.isSuccess` становится `false`, если в любом чанке была ошибка. `getErrorMessages()` возвращает по одному сообщению на каждый неудавшийся вызов. Успешные вызовы всё равно в `getData()` — частичный прогресс сохраняется.
+- `ParamsFactory.getBatchProcessing()` повышает порог времени операций и снижает частоту запросов, что держит очередь портала отзывчивой, пока долгая миграция идёт рядом с живым UI-трафиком.
+- Именование запроса через `options.requestId` упрощает фильтрацию логов на стороне портала и дедупликацию случайных перезапусков.
 
-## Limitations {#limitations}
+## Ограничения {#limitations}
 
-- The two-tuple `calls` form is required: `BatchByChunkV2` deliberately rejects named-object commands because chunk boundaries would split the names apart.
-- Each command counts against the daily method-call budget. For tens of thousands of updates, schedule the script to run during off-peak hours and consider splitting by responsible user.
-- Bitrix24's `crm.item.update` validates `stageId` against the deal's category. A typo in `newStageId` returns a per-call error — visible in `getErrorMessages()` — but the whole script does not abort thanks to `isHaltOnError: false`.
-- Atomic rollback is **not** supported. If you need transactional behavior, dump current values into a separate CSV first and run a second migration to restore.
+- Требуется форма `calls` из кортежей-двоек: `BatchByChunkV2` намеренно отклоняет команды в виде именованных объектов, потому что границы чанков разорвали бы имена.
+- Каждая команда учитывается в дневном бюджете вызовов. Для десятков тысяч обновлений запускайте скрипт в непиковые часы и подумайте о разбиении по ответственному пользователю.
+- `crm.item.update` Bitrix24 валидирует `stageId` относительно категории сделки. Опечатка в `newStageId` возвращает ошибку конкретного вызова — видна в `getErrorMessages()` — но весь скрипт не прерывается благодаря `isHaltOnError: false`.
+- Атомарный откат **не** поддерживается. Если нужно транзакционное поведение, сначала выгрузите текущие значения в отдельный CSV и запустите вторую миграцию для восстановления.
 
-## See also {#see-also}
+## См. также {#see-also}
 
-- [`BatchByChunkV2.make()`](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/) — full method reference.
-- [`BatchV2.make()`](/docs/working-with-the-rest-api/batch-rest-api-ver2/) — when you have ≤ 50 calls and want named results.
-- [Restrictions System](/docs/working-with-the-rest-api/limiters/) — choosing a `restrictionParams` preset.
+- [`BatchByChunkV2.make()`](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/) — полный справочник метода.
+- [`BatchV2.make()`](/docs/working-with-the-rest-api/batch-rest-api-ver2/) — когда у вас ≤ 50 вызовов и нужны именованные результаты.
+- [Система ограничений](/docs/working-with-the-rest-api/limiters/) — выбор пресета `restrictionParams`.

--- a/docs/content/docs/99.examples/4.erp-sync.md
+++ b/docs/content/docs/99.examples/4.erp-sync.md
@@ -1,46 +1,46 @@
 ---
-title: ERP / 1C contact sync
-description: 'Two-way contact sync between Bitrix24 and an external ERP. Match by INN (primary) or email (fallback). Cron every hour.'
-navigation.title: ERP sync
+title: Синхронизация контактов с ERP / 1С
+description: 'Двусторонняя синхронизация контактов между Bitrix24 и внешней ERP. Сопоставление по ИНН (основное) или email (запасное). Cron каждый час.'
+navigation.title: Синхронизация ERP
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/04-erp-sync.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Pulls contacts from both Bitrix24 (via `actions.v2.fetchList.make`) and an external ERP (mocked in the recipe — replace with your client). Matches them by tax id (`ufCrmInn`) primarily and email as a fallback. Creates missing rows on each side and syncs changed name fields back to Bitrix24.
+Выгружает контакты и из Bitrix24 (через `actions.v2.fetchList.make`), и из внешней ERP (в рецепте замокано — замените своим клиентом). Сопоставляет их по налоговому id (`ufCrmInn`) в первую очередь и по email как запасной вариант. Создаёт недостающие записи с каждой стороны и синхронизирует изменённые поля имени обратно в Bitrix24.
 
-## Stack {#stack}
+## Стек {#stack}
 
 Node.js 18+, `node-cron`.
 
-## Install {#install}
+## Установка {#install}
 
 ```bash
 pnpm add node-cron
 ```
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 04-erp-sync.ts
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/04-erp-sync.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/04-erp-sync.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- ERP-side functions (`fetchErpContacts`, `createErpContact`, `updateErpContact`) are stubs. Plug in your client (1C OData, REST, etc.).
-- The matching key is `ufCrmInn` — adjust the field name to whatever your custom-field namespace uses.
-- For thousands of contacts the per-row `createBitrixContact` await loop is the bottleneck. Replace it with `actions.v2.batchByChunk.make({ calls: erpContacts.map((e) => ['crm.item.add', { entityTypeId: 3, fields: ... }]), options: { isHaltOnError: false } })` — see [recipe 5 (Disk files)](/docs/examples/disk-files/) for the basic `batch.make` shape and the `b24jssdk-rest` skill for `batchByChunk.make` details.
+- Функции на стороне ERP (`fetchErpContacts`, `createErpContact`, `updateErpContact`) — заглушки. Подключите свой клиент (1С OData, REST и т.д.).
+- Ключ сопоставления — `ufCrmInn`; подгоните имя поля под пространство имён ваших пользовательских полей.
+- Для тысяч контактов узкое место — построчный цикл с await `createBitrixContact`. Замените его на `actions.v2.batchByChunk.make({ calls: erpContacts.map((e) => ['crm.item.add', { entityTypeId: 3, fields: ... }]), options: { isHaltOnError: false } })` — базовую форму `batch.make` см. в [рецепте 5 (Файлы Диска)](/docs/examples/disk-files/), а детали `batchByChunk.make` — в скиле `b24jssdk-rest`.

--- a/docs/content/docs/99.examples/5.disk-files.md
+++ b/docs/content/docs/99.examples/5.disk-files.md
@@ -1,44 +1,44 @@
 ---
-title: Disk — storages, folders, files
-description: 'List storages and folder children, create subfolders, inspect files. File upload (multipart) is intentionally out of scope.'
-navigation.title: Disk files
+title: Диск — хранилища, папки, файлы
+description: 'Список хранилищ и содержимого папок, создание подпапок, просмотр файлов. Загрузка файлов (multipart) намеренно вне области.'
+navigation.title: Файлы Диска
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/05-disk-files.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Touches every read/write operation Bitrix24 Disk supports without multipart: `disk.storage.getlist`, `disk.folder.getchildren` (paged via `actions.v2.callList.make`), `disk.folder.addsubfolder`, `disk.file.get`. Includes an `actions.v2.batch.make` example combining storages and root-folder listing in one round-trip.
+Затрагивает все операции чтения/записи Bitrix24 Диска без multipart: `disk.storage.getlist`, `disk.folder.getchildren` (постранично через `actions.v2.callList.make`), `disk.folder.addsubfolder`, `disk.file.get`. Включает пример `actions.v2.batch.make`, объединяющий список хранилищ и корневой папки в один round-trip.
 
-## Stack {#stack}
+## Стек {#stack}
 
-Node.js 18+. No external dependencies.
+Node.js 18+. Без внешних зависимостей.
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 ```
 
-> **Webhook scope required:** the incoming webhook must have the **disk** scope enabled.
-> Bitrix24 portal → Developer resources → Inbound webhooks → edit → tick **Диск (disk)**.
-> Without it all Disk API calls return `insufficient_scope` (HTTP 401).
+> **Нужен scope вебхука:** у входящего вебхука должен быть включён scope **disk**.
+> Портал Bitrix24 → Ресурсы разработчика → Входящие вебхуки → изменить → отметьте **Диск (disk)**.
+> Без него все вызовы Disk API возвращают `insufficient_scope` (HTTP 401).
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 05-disk-files.ts
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/05-disk-files.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/05-disk-files.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- Uploading a binary requires `disk.folder.uploadfile` with `multipart/form-data`. The SDK can do this via the underlying `Http` transport, but it isn't a drop-in `actions.v2.call.make` invocation — that recipe is on the suggestion list.
-- Disk methods use **classic** uppercase fields: `ID`, `NAME`, `PARENT_ID`, `ROOT_OBJECT_ID`. There is no v3 Disk API.
-- `disk.folder.getchildren` is paged — always go through `actions.v2.callList.make` (or `actions.v2.fetchList.make` for large folders), not a single `actions.v2.call.make`.
+- Загрузка бинарника требует `disk.folder.uploadfile` с `multipart/form-data`. SDK может это через нижележащий транспорт `Http`, но это не «drop-in» вызов `actions.v2.call.make` — такой рецепт в списке предложений.
+- Методы Диска используют **классические** поля в верхнем регистре: `ID`, `NAME`, `PARENT_ID`, `ROOT_OBJECT_ID`. v3 Disk API не существует.
+- `disk.folder.getchildren` постраничный — всегда идите через `actions.v2.callList.make` (или `actions.v2.fetchList.make` для больших папок), а не через одиночный `actions.v2.call.make`.

--- a/docs/content/docs/99.examples/5.pull-subscribe-frame.md
+++ b/docs/content/docs/99.examples/5.pull-subscribe-frame.md
@@ -1,10 +1,10 @@
 ---
-title: 'Recipe: Subscribe to Pull events'
-description: 'Open a live channel from a Bitrix24 frame app and react to push events using useB24Helper + the Pull client.'
+title: 'Рецепт: подписка на события Pull'
+description: 'Открыть живой канал из frame-приложения Bitrix24 и реагировать на push-события через useB24Helper + Pull-клиент.'
 audited: 2026-05-29
 category: 'examples'
 navigation:
-  title: Pull subscribe
+  title: Подписка на Pull
 links:
   - label: useB24Helper
     iconName: GitHubIcon
@@ -15,24 +15,24 @@ links:
 ---
 
 ::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
+Мы всё ещё дорабатываем эту страницу. Некоторых данных здесь может не хватать — скоро дополним.
 ::
 
-## Goal {#goal}
+## Цель {#goal}
 
-A frame app that gets real-time updates from Bitrix24 — for example, the badge counter goes up when a new chat message arrives or when a CRM activity changes hands. The Pull client multiplexes WebSocket and long-polling transports; you only see one callback.
+Frame-приложение, которое получает обновления в реальном времени от Bitrix24 — например, счётчик-бейдж растёт, когда приходит новое сообщение в чате или меняется ответственный по делу CRM. Pull-клиент мультиплексирует транспорты WebSocket и long-polling; вы видите только один callback.
 
-## Stack & Prerequisites {#stack-prerequisites}
+## Стек и предпосылки {#stack-prerequisites}
 
-- Vue 3 + Vite (or Nuxt) running inside a Bitrix24 placement
+- Vue 3 + Vite (или Nuxt), работающие внутри placement Bitrix24
 - `@bitrix24/b24jssdk@^1.0.0`
-- The portal must have the Pull module enabled (it is on every cloud and most on-premise installations)
+- На портале должен быть включён модуль Pull (он есть на каждом облаке и большинстве коробочных инсталляций)
 
 ```bash
 pnpm add @bitrix24/b24jssdk
 ```
 
-## Full Example {#full-example}
+## Полный пример {#full-example}
 
 `src/components/PullPanel.vue`:
 
@@ -66,14 +66,14 @@ function handleEvent(message: TypePullMessage) {
     at: new Date().toLocaleTimeString(),
     command: message.command
   })
-  // Keep the visible log short.
+  // Держим видимый лог коротким.
   if (events.value.length > 20) events.value.length = 20
 }
 
 onMounted(async () => {
   $b24 = await initializeB24Frame()
 
-  // App + Profile are required so the helper can register a Pull channel.
+  // App + Profile нужны, чтобы хелпер мог зарегистрировать Pull-канал.
   await initB24Helper(
     $b24,
     [LoadDataType.App, LoadDataType.Profile],
@@ -81,8 +81,8 @@ onMounted(async () => {
   )
 
   usePullClient()
-  // Listen to events from the `crm` module. Use `'application'` (default) for
-  // your own app's custom events.
+  // Слушаем события модуля `crm`. Используйте `'application'` (по умолчанию) для
+  // собственных событий вашего приложения.
   useSubscribePullClient(handleEvent, 'crm')
   startPullClient()
 })
@@ -106,25 +106,25 @@ onBeforeUnmount(() => {
 </template>
 ```
 
-## Run It {#run-it}
+## Запуск {#run-it}
 
-Open the app inside Bitrix24, then trigger a CRM event in another tab — drag a deal to a new stage, add an activity, change the responsible person. Within a second the event command (e.g. `crm_deal_update`) appears at the top of the list. The component keeps the last 20 events visible.
+Откройте приложение внутри Bitrix24, затем вызовите событие CRM в другой вкладке — перетащите сделку на новую стадию, добавьте дело, смените ответственного. В течение секунды команда события (например, `crm_deal_update`) появляется вверху списка. Компонент держит видимыми последние 20 событий.
 
-## How It Works {#how-it-works}
+## Как это работает {#how-it-works}
 
-- `useB24Helper()` returns a closure over a single `B24HelperManager` instance. It is **not** a Vue composable — it doesn't read Vue lifecycle hooks. You wire it into `onMounted` / `onBeforeUnmount` yourself.
-- `initB24Helper($b24, dataTypes, requestId)` loads the data the Pull client needs to register a channel. Without `LoadDataType.App` and `LoadDataType.Profile` the subsequent `usePullClient()` call throws.
-- `usePullClient()` instantiates the Pull transport (WebSocket with long-polling fallback). `useSubscribePullClient(handler, moduleId)` registers your callback for that module. `startPullClient()` actually opens the connection — call it last.
-- `destroyB24Helper()` tears down the transport and unregisters subscribers. Calling it on unmount prevents the WebSocket from leaking when the app slider closes.
+- `useB24Helper()` возвращает замыкание над одним экземпляром `B24HelperManager`. Это **не** Vue composable — он не читает хуки жизненного цикла Vue. Вы сами подключаете его в `onMounted` / `onBeforeUnmount`.
+- `initB24Helper($b24, dataTypes, requestId)` загружает данные, нужные Pull-клиенту для регистрации канала. Без `LoadDataType.App` и `LoadDataType.Profile` последующий вызов `usePullClient()` выбрасывает исключение.
+- `usePullClient()` создаёт транспорт Pull (WebSocket с фолбэком на long-polling). `useSubscribePullClient(handler, moduleId)` регистрирует ваш callback для этого модуля. `startPullClient()` собственно открывает соединение — вызывайте его последним.
+- `destroyB24Helper()` разрушает транспорт и снимает подписчиков. Вызов при размонтировании предотвращает утечку WebSocket при закрытии слайдера приложения.
 
-## Limitations {#limitations}
+## Ограничения {#limitations}
 
-- The order **must** be `initB24Helper` → `usePullClient` → `useSubscribePullClient` → `startPullClient`. Calling `useSubscribePullClient` before `usePullClient` throws `PullClient is not initialized`. The error is intentional — it surfaces wiring mistakes early.
-- `useB24Helper()` returns one shared instance per closure. If you create a second `useB24Helper()` and call `initB24Helper` again, the second call re-uses the existing manager rather than building a new one.
-- `moduleId` defaults to `'application'`. To listen to portal modules (`'crm'`, `'tasks'`, `'im'`, …) pass them explicitly. Subscribing to multiple modules requires multiple `useSubscribePullClient` calls.
-- Pull events are best-effort. They are great for "wake the UI up", not for "this is the source of truth". Always re-fetch via REST when the user takes an action that depends on freshness.
+- Порядок **обязан** быть `initB24Helper` → `usePullClient` → `useSubscribePullClient` → `startPullClient`. Вызов `useSubscribePullClient` до `usePullClient` выбрасывает `PullClient is not initialized`. Ошибка намеренная — она рано выявляет ошибки подключения.
+- `useB24Helper()` возвращает один общий экземпляр на замыкание. Если вы создадите второй `useB24Helper()` и снова вызовете `initB24Helper`, второй вызов переиспользует существующий менеджер, а не создаёт новый.
+- `moduleId` по умолчанию `'application'`. Чтобы слушать модули портала (`'crm'`, `'tasks'`, `'im'`, …), передавайте их явно. Подписка на несколько модулей требует нескольких вызовов `useSubscribePullClient`.
+- События Pull — best-effort. Они отлично подходят для «разбудить UI», но не для «это источник истины». Всегда перезапрашивайте через REST, когда действие пользователя зависит от свежести.
 
-## See also {#see-also}
+## См. также {#see-also}
 
-- [Recipe: Frame app skeleton](/docs/examples/frame-app-skeleton/) — minimal frame app this builds on top of.
-- [`B24Frame`](/docs/working-with-the-rest-api/frame/) — the iframe entry point.
+- [Рецепт: скелет frame-приложения](/docs/examples/frame-app-skeleton/) — минимальное frame-приложение, на котором это построено.
+- [`B24Frame`](/docs/working-with-the-rest-api/frame/) — точка входа iframe.

--- a/docs/content/docs/99.examples/6.telegram-bot.md
+++ b/docs/content/docs/99.examples/6.telegram-bot.md
@@ -1,49 +1,49 @@
 ---
-title: Telegram bot for new deals
-description: 'Poll new CRM deals every two minutes; notify a Telegram chat with an HTML-formatted card.'
-navigation.title: Telegram bot
+title: Telegram-бот для новых сделок
+description: 'Опрашивает новые сделки CRM каждые две минуты; уведомляет Telegram-чат HTML-карточкой.'
+navigation.title: Telegram-бот
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/06-telegram-bot.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Watches `crm.item.list` for deals with `id > lastSeenDealId` and base stage `NEW`. For every new deal it loads the related contact (`crm.item.get`), formats an HTML card, and posts it to a Telegram chat via `grammy`. Provides `/start` and `/status` slash commands.
+Следит за `crm.item.list` на предмет сделок с `id > lastSeenDealId` и базовой стадией `NEW`. Для каждой новой сделки загружает связанный контакт (`crm.item.get`), форматирует HTML-карточку и публикует её в Telegram-чат через `grammy`. Предоставляет slash-команды `/start` и `/status`.
 
-## Stack {#stack}
+## Стек {#stack}
 
 Node.js 18+, `grammy`, `node-cron`.
 
-## Install {#install}
+## Установка {#install}
 
 ```bash
 pnpm add grammy node-cron
 ```
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 export TELEGRAM_BOT_TOKEN='...'   # @BotFather
-export TELEGRAM_CHAT_ID='...'     # destination chat
+export TELEGRAM_CHAT_ID='...'     # чат назначения
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 06-telegram-bot.ts
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/06-telegram-bot.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/06-telegram-bot.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- `lastSeenDealId` lives in memory — persist it to survive restarts.
-- For interactive actions (assign, mark as junk) extend with grammy's `InlineKeyboard`.
-- HTML escaping is handled inline. If you change the message format keep `parse_mode: 'HTML'` and escape user-controlled strings.
-- When the per-tick batch is large (lots of new deals at once), replace the per-deal `fetchContactName` call with a single `actions.v2.batch.make` that fetches every contact in one round-trip. Example shape: `actions.v2.batch.make({ calls: deals.map((d) => ['crm.item.get', { entityTypeId: 3, id: d.contactId }]) })`.
+- `lastSeenDealId` живёт в памяти — сохраняйте его, чтобы пережить перезапуски.
+- Для интерактивных действий (назначить, пометить мусором) расширьте через `InlineKeyboard` из grammy.
+- HTML-экранирование делается прямо в коде. Если меняете формат сообщения, сохраняйте `parse_mode: 'HTML'` и экранируйте пользовательские строки.
+- Когда батч за тик большой (много новых сделок сразу), замените построчный вызов `fetchContactName` на один `actions.v2.batch.make`, который загружает все контакты за один round-trip. Пример формы: `actions.v2.batch.make({ calls: deals.map((d) => ['crm.item.get', { entityTypeId: 3, id: d.contactId }]) })`.

--- a/docs/content/docs/99.examples/7.webhook-handler.md
+++ b/docs/content/docs/99.examples/7.webhook-handler.md
@@ -1,50 +1,50 @@
 ---
-title: Outbound webhook handler
-description: 'Express server that receives Bitrix24 outbound events, fetches details via REST, dispatches by event name. Always returns 200.'
-navigation.title: Webhook handler
+title: Обработчик исходящих вебхуков
+description: 'Express-сервер, который принимает исходящие события Bitrix24, подгружает детали через REST, маршрутизирует по имени события. Всегда возвращает 200.'
+navigation.title: Обработчик вебхуков
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/07-webhook-handler.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Stands up an Express endpoint at `POST /webhook` that maps `ONCRMDEALADD`, `ONCRMDEALUPDATE`, `ONCRMDEALDELETE` events to handlers. Each handler calls `crm.item.get` to enrich the payload (Bitrix24 only ships the entity id) and runs your downstream logic. Provides a `GET /health` endpoint for orchestration probes.
+Поднимает Express-endpoint на `POST /webhook`, который сопоставляет события `ONCRMDEALADD`, `ONCRMDEALUPDATE`, `ONCRMDEALDELETE` обработчикам. Каждый обработчик вызывает `crm.item.get`, чтобы обогатить payload (Bitrix24 присылает только id сущности), и выполняет вашу логику. Предоставляет endpoint `GET /health` для проб оркестрации.
 
-## Stack {#stack}
+## Стек {#stack}
 
 Node.js 18+, `express`.
 
-## Install {#install}
+## Установка {#install}
 
 ```bash
 pnpm add express
 ```
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
-export PORT=3001  # default
+export PORT=3001  # по умолчанию
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 07-webhook-handler.ts
-# expose locally for tests:
+# пробросить локально для тестов:
 npx ngrok http 3001
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/07-webhook-handler.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/07-webhook-handler.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- Bitrix24 outbound events POST `application/x-www-form-urlencoded` — Express's `urlencoded({ extended: true })` parser flattens `data[FIELDS][ID]` to `payload.data.FIELDS.ID`.
-- Always return `200` regardless of handler outcome. Non-2xx triggers Bitrix24 retries for up to 24 hours.
-- Event registration is a one-off setup — see [recipe 11 (Outbound event registration)](/docs/examples/event-registration/) for `event.bind` / `event.unbind` from the SDK.
-- **Verify the request origin in production.** Set `B24_APPLICATION_TOKEN` to the value from the Bitrix24 dev console (Local Application → application_token); the recipe checks `payload.auth?.application_token` against it and silently drops requests that don't match. Without this guard, anyone who knows your URL can replay arbitrary events.
+- Исходящие события Bitrix24 шлют POST `application/x-www-form-urlencoded` — парсер Express `urlencoded({ extended: true })` разворачивает `data[FIELDS][ID]` в `payload.data.FIELDS.ID`.
+- Всегда возвращайте `200` независимо от исхода обработчика. Не-2xx запускает повторы Bitrix24 на срок до 24 часов.
+- Регистрация событий — разовая настройка; про `event.bind` / `event.unbind` из SDK см. [рецепт 11 (Регистрация исходящих событий)](/docs/examples/event-registration/).
+- **Проверяйте источник запроса в production.** Задайте `B24_APPLICATION_TOKEN` равным значению из dev-консоли Bitrix24 (Локальное приложение → application_token); рецепт сверяет с ним `payload.auth?.application_token` и молча отбрасывает несовпадающие запросы. Без этой защиты любой, кто знает ваш URL, может повторять произвольные события.

--- a/docs/content/docs/99.examples/8.ai-assistant.md
+++ b/docs/content/docs/99.examples/8.ai-assistant.md
@@ -1,48 +1,48 @@
 ---
-title: AI assistant — analyse a deal, create a follow-up task
-description: 'Load a deal and its activities, ask GPT-4o for the next-best action, create a task bound to the deal with priority and deadline.'
-navigation.title: AI assistant
+title: AI-ассистент — анализ сделки, создание задачи
+description: 'Загружает сделку и её дела, спрашивает у GPT-4o лучшее следующее действие, создаёт задачу, привязанную к сделке, с приоритетом и дедлайном.'
+navigation.title: AI-ассистент
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/08-ai-assistant.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Given a deal id on the command line, it fetches the deal (`crm.item.get` via `actions.v2.call.make`) and its activity timeline (`crm.activity.list` via `actions.v2.callList.make`). Sends a structured prompt to GPT-4o, asks for a JSON recommendation, and creates a task (`tasks.task.add` via `actions.v3.call.make`) bound to the deal via `UF_CRM_TASK`.
+По id сделки из командной строки загружает сделку (`crm.item.get` через `actions.v2.call.make`) и её таймлайн дел (`crm.activity.list` через `actions.v2.callList.make`). Отправляет структурированный промпт в GPT-4o, просит JSON-рекомендацию и создаёт задачу (`tasks.task.add` через `actions.v3.call.make`), привязанную к сделке через `UF_CRM_TASK`.
 
-## Stack {#stack}
+## Стек {#stack}
 
 Node.js 18+, `openai`.
 
-## Install {#install}
+## Установка {#install}
 
 ```bash
 pnpm add openai
 ```
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 export OPENAI_API_KEY='sk-...'
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 08-ai-assistant.ts <DEAL_ID>
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/08-ai-assistant.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/08-ai-assistant.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- The deal lookup uses **v3** (camelCase) fields; the activity list uses **classic** uppercase fields (`OWNER_TYPE_ID`, `OWNER_ID`, `CREATED`).
-- Switching to OpenAI tool-calling (`tools` parameter, function-calling loop) is the modern shape — see the suggested-examples list.
-- The prompt asks for a strict JSON response and uses `response_format: { type: 'json_object' }` to enforce it.
-- Priority mapping: `high → 2`, `medium → 1`, `low → 0` matches Bitrix24's task priority enum.
+- Поиск сделки использует **v3**-поля (camelCase); список дел — **классические** поля в верхнем регистре (`OWNER_TYPE_ID`, `OWNER_ID`, `CREATED`).
+- Переход на tool-calling OpenAI (параметр `tools`, цикл function-calling) — современная форма; см. список предлагаемых примеров.
+- Промпт требует строгий JSON-ответ и использует `response_format: { type: 'json_object' }`, чтобы это обеспечить.
+- Маппинг приоритета: `high → 2`, `medium → 1`, `low → 0` соответствует enum приоритета задач Bitrix24.

--- a/docs/content/docs/99.examples/9.web-search-llm.md
+++ b/docs/content/docs/99.examples/9.web-search-llm.md
@@ -1,49 +1,49 @@
 ---
-title: Web search + LLM with timeline write-back
-description: 'Two-step RAG: ask any web-search provider, run the result through your LLM with [N] citations, post the answer as a CRM timeline comment on a deal.'
-navigation.title: Web search + LLM
+title: Веб-поиск + LLM с записью в таймлайн
+description: 'Двухшаговый RAG: запрос к любому провайдеру веб-поиска, прогон результата через ваш LLM с цитатами [N], публикация ответа комментарием в таймлайн CRM на сделке.'
+navigation.title: Веб-поиск + LLM
 category: examples
 links:
-  - label: Source on GitHub
+  - label: Исходник на GitHub
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/09-web-search-llm.ts
 ---
 
-## What it does {#what-it-does}
+## Что делает {#what-it-does}
 
-Bitrix24 REST has no native web search or LLM endpoint. This recipe demonstrates the bridge pattern: use any external provider for search/LLM, then push the answer back into Bitrix24 via the SDK. The handler writes the LLM's cited answer to the deal's timeline as a comment.
+В REST Bitrix24 нет нативного endpoint для веб-поиска или LLM. Этот рецепт демонстрирует паттерн моста: используйте любой внешний провайдер для поиска/LLM, затем верните ответ обратно в Bitrix24 через SDK. Обработчик пишет ответ LLM с цитатами в таймлайн сделки комментарием.
 
-## Stack {#stack}
+## Стек {#stack}
 
-Node.js 18+, `openai`. Web search is BYOC — replace `webSearch()` with your call to Tavily, Brave, SerpAPI, or any other provider.
+Node.js 18+, `openai`. Веб-поиск — BYOC: замените `webSearch()` своим вызовом к Tavily, Brave, SerpAPI или любому другому провайдеру.
 
-## Install {#install}
+## Установка {#install}
 
 ```bash
 pnpm add openai
 ```
 
-## Environment {#environment}
+## Переменные окружения {#environment}
 
 ```bash
 export B24_HOOK='https://your.bitrix24.com/rest/1/secret'
 export OPENAI_API_KEY='sk-...'
-export SEARCH_API_KEY='...'   # your provider's key
+export SEARCH_API_KEY='...'   # ключ вашего провайдера
 ```
 
-## Run {#run}
+## Запуск {#run}
 
 ```bash
 npx tsx 09-web-search-llm.ts <DEAL_ID> "<question>"
 ```
 
-## Source {#source}
+## Исходник {#source}
 
 [`skills/b24jssdk-recipes/examples/09-web-search-llm.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/examples/09-web-search-llm.ts).
 
-## Notes {#notes}
+## Примечания {#notes}
 
-- The `webSearch()` function in the recipe is a stub. Replace it with the actual call for your provider; the rest of the recipe is unaffected.
-- The LLM is told to cite every fact with `[N]` where N is `results[].id`. The recipe appends the matching URL list to the timeline comment.
-- `crm.timeline.comment.add` is a classic API method. The recipe uses the numeric `ENTITY_TYPE_ID: 2` (≡ `EnumCrmEntityTypeId.deal`) — that form is accepted on every portal version we've tested. The string form `ENTITY_TYPE: 'deal'` also works on most modern portals; swap to it if your downstream expects the symbolic name.
-- For VibeCode-managed AI Router or Bitrix-search instead of an external provider, see the `b24jssdk-vibecode` skill.
+- Функция `webSearch()` в рецепте — заглушка. Замените её реальным вызовом вашего провайдера; остальное в рецепте не затрагивается.
+- LLM просят цитировать каждый факт через `[N]`, где N — `results[].id`. Рецепт добавляет к комментарию таймлайна соответствующий список URL.
+- `crm.timeline.comment.add` — классический метод API. Рецепт использует числовой `ENTITY_TYPE_ID: 2` (≡ `EnumCrmEntityTypeId.deal`) — эта форма принимается на всех протестированных нами версиях портала. Строковая форма `ENTITY_TYPE: 'deal'` тоже работает на большинстве современных порталов; переключитесь на неё, если ваш код ожидает символьное имя.
+- Для AI Router под управлением VibeCode или Bitrix-поиска вместо внешнего провайдера см. скил `b24jssdk-vibecode`.


### PR DESCRIPTION
## Кратко

**Stage 3d (финальный этап перевода)** — раздел `99.examples/**`: **22 файла** (`.navigation.yml` + `0.index` + 20 рецептов). С этим PR **весь `docs/content/` переведён на русский — 87/87 (100%)**.

Stage 3 целиком:
- **3a** — i18n-kit + механика (#9)
- **3b** — getting-started (#20)
- **3c** — working-with-rest-api: PR-A #21, PR-B #22, PR-C #23
- **3d (этот)** — examples (cookbook + расширенный каталог + UI-витрины)

## Переведено (22 файла)

**Навигация/индекс:** `.navigation.yml`, `0.index` (карточки cookbook/каталога/UI-витрин)
**Cookbook + каталог (расширенный):** `1.crm-analytics`, `1.dashboard-deals-csv`, `2.mass-messaging`, `2.frame-app-skeleton`, `3.task-automation`, `3.webhook-cli-node`, `4.bulk-update-deals`, `4.erp-sync`, `5.disk-files`, `5.pull-subscribe-frame`, `6.telegram-bot`, `7.webhook-handler`, `8.ai-assistant`, `9.web-search-llm`, `10.error-handling`, `11.event-registration`, `12.oauth-install`
**UI-витрины:** `10.entity-list`, `20.app-installation-wizard`, `30.node-hook-company-export`

## Применённые правила (по `docs/i18n/`)

- ✅ Переведена проза, заголовки секций (`What it does`→`Что делает`, `Stack`→`Стек`, `Run`→`Запуск`, `Notes`→`Примечания`, `Limitations`→`Ограничения`, `How It Works`→`Как это работает`, `See also`→`См. также` …), описания `::card`/`::note`/`::caution`/`::warning`, frontmatter `title`/`description`/`navigation.title`
- ✅ Якоря `{#en-anchor}`, `category`/`audited`/`links.iconName`/`links.to` — нетронуты
- ✅ **JSX/Vue-разметка в примерах — английская** (текст шаблонов: `Hello from`, `Switch theme`, `Live events` …); переведены только **педагогические комментарии** в коде; `// @check-ignore:` — сохранён
- ✅ `console.*`/`$logger.*`/`throw new Error`, строки ошибок, sample-вывод (`# fetched: 4350`), команды (`pnpm`/`npx`/`export`/`curl`), имена методов/классов SDK, npm-пакеты, URL — нетронуты/verbatim
- ✅ Регэкспы (`/\r?\n/`), литералы `\n`/`\r`, `"type": "module"`, `package.json` — сохранены байт-в-байт
- ✅ Ссылки на upstream issue (`bitrix24/b24jssdk`) — не переписаны

## Проверка

CI (lint/typecheck/build) — финальная проверка; `skills:typecheck` в скоупе SDK-репо, здесь зеркалится только текст.

## Итог
**Зеркало переведено на 100% (87/87).** Дальше — режим **sync** из upstream по `.github/AGENTS-SYNC-RUNBOOK.md` при новых релизах SDK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS)_