### PR TITLE
fix(content): llms-txt.md — clean autolinks for llms.txt example URLs

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -65,5 +65,5 @@ Windsurf может напрямую обращаться к LLMs.txt-файла
 
 #### Примеры для ChatGPT, Claude и других LLM:
 
-- «Используя документацию Bitrix24 JS SDK из https://bitrix-tools.github.io/b24jssdk/llms.txt»
-- «Следуйте полному руководству Bitrix24 JS SDK из https://bitrix-tools.github.io/b24jssdk/llms-full.txt»
+- «Используя документацию Bitrix24 JS SDK из <https://bitrix-tools.github.io/b24jssdk/llms.txt>»
+- «Следуйте полному руководству Bitrix24 JS SDK из <https://bitrix-tools.github.io/b24jssdk/llms-full.txt>»


### PR DESCRIPTION
На странице `docs/.../7.ai/2.llms-txt.md` закрывающая «ёлочка» `»` приклеивалась к автолинку URL, и ссылка рендерилась с лишним символом на конце (`https://…/llms.txt»`). Обернул оба URL в угловые скобки `<…>` — теперь это явный автолинк, а `»` остаётся текстом снаружи.

Затронут только этот контент-файл (2 строки). Ссылка на `github.com/bitrix24/...` (исходник SDK) не трогалась.

Docs-only. No BREAKING CHANGE.

https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS)_