### PR TITLE
refactor(docs): adapt server routes to b24jssdk (were copied from b24ui)

### DIFF
--- a/docs/server/routes/raw/[...slug].md.get.ts
+++ b/docs/server/routes/raw/[...slug].md.get.ts
@@ -6,16 +6,18 @@ import collections from '#content/manifest'
 import { transformMDC } from '../../utils/transformMDC'
 import { clearMD } from '../../utils/clearMD'
 
-// const DOMAIN = 'https://bitrix24.github.io/b24ui'
-
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const baseUrl = `${config.public.canonicalUrl}${config.public.baseUrl}`
 
+  const notFound = (reason: string) => {
+    setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+    return `---\ntitle: Not Found\n---\n\n# Page Not Found\n\n${reason} Browse the [sitemap](${config.public.baseUrl}/sitemap.md) to find available pages.\n`
+  }
+
   const slug = getRouterParams(event)['slug.md']
   if (!slug?.endsWith('.md')) {
-    setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
-    return `---\ntitle: Not Found\n---\n\n# Page Not Found\n\nThe requested page does not exist. Browse the [sitemap](${config.public.baseUrl}/sitemap.md) to find available pages.\n`
+    return notFound('The requested page does not exist.')
   }
 
   let path = withLeadingSlash(slug.replace('.md', ''))
@@ -34,8 +36,7 @@ export default defineEventHandler(async (event) => {
   }
 
   if (!page) {
-    setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
-    return `---\ntitle: Not Found\n---\n\n# Page Not Found\n\nThe page \`${config.public.baseUrl}${path}\` does not exist. Browse the [sitemap](${config.public.baseUrl}/sitemap.md) to find available pages.\n`
+    return notFound(`The page \`${config.public.baseUrl}${path}\` does not exist.`)
   }
 
   await transformMDC(event, page as any)

--- a/docs/server/routes/raw/index.md.get.ts
+++ b/docs/server/routes/raw/index.md.get.ts
@@ -1,16 +1,14 @@
 import { queryCollection } from '@nuxt/content/server'
 
-// const DOMAIN = 'https://bitrix24.github.io/b24ui'
-
 export default defineCachedEventHandler(async (event) => {
   const config = useRuntimeConfig()
-  const baseUrl = `${config.public.canonicalUrl}${config.public.baseUrl}`
-  const DOMAIN = baseUrl
+  const DOMAIN = `${config.public.canonicalUrl}${config.public.baseUrl}`
 
-  const page = await queryCollection(event, 'index').first() as any
+  const page = await queryCollection(event, 'index').first() as { title?: string, description?: string } | null
 
-  const title = page?.title || 'Bitrix24 UI'
-  const description = page?.description || 'A comprehensive Vue UI component library (Nuxt optional) with 125+ accessible, Tailwind CSS components for building modern web applications.'
+  const title = page?.title || 'Bitrix24 JS SDK'
+  const description = page?.description
+    || 'Bitrix24 JS SDK for using the Bitrix24 REST API in local, production applications or via webhooks.'
 
   const frontmatter = [
     '---',
@@ -22,36 +20,37 @@ export default defineCachedEventHandler(async (event) => {
     ''
   ].join('\n')
 
-  // - MCP Server Card: <${DOMAIN}/.well-known/mcp/server-card.json>
-  // - MCP endpoint: <${DOMAIN}/mcp>
-  // @todo fix tg en (https://t.me/b24_dev) | ru (https://t.me/bitrix24apps)
-
   const body = `# ${title}
 
 > ${description}
 
 ## About
 
-Bitrix24 UI is a free and open source Vue UI library powered by [Reka UI](https://reka-ui.com/) and [Tailwind CSS](https://tailwindcss.com/). It works with both Nuxt and plain Vue applications.
+The Bitrix24 JS SDK (\`@bitrix24/b24jssdk\`) is a free and open-source JavaScript/TypeScript library for the Bitrix24 REST API. It runs in the browser inside Bitrix24 applications (B24Frame), on the server through inbound webhooks (B24Hook) or OAuth server apps (B24OAuth), and in any modern JavaScript runtime.
 
-- 125+ accessible, production-ready components
-- Built on Reka UI (WAI-ARIA compliant primitives)
-- Tailwind CSS theming with CSS variables and Tailwind Variants
-- TypeScript support with full auto-completion
-- Server-side rendering (SSR) compatible
-- Dark mode support and 19 languages via i18n
+- Three authentication modes: B24Frame (embedded apps), B24Hook (webhooks), B24OAuth (server apps)
+- REST API v2 and v3: single calls, list iteration, and batch requests
+- Built-in request batching, rate-limit handling, and automatic retries
+- Helper managers for profile, application, payment, license, currency and options data
+- Pluggable logging (including Telegram) and structured error codes
+- First-class TypeScript types with full auto-completion
+- Works with Nuxt, Vue, React, Node.js and UMD builds
 
 ## Installation
 
 - Nuxt: <${DOMAIN}/raw/docs/getting-started/installation/nuxt.md>
 - Vue: <${DOMAIN}/raw/docs/getting-started/installation/vue.md>
+- React: <${DOMAIN}/raw/docs/getting-started/installation/react.md>
+- Node.js: <${DOMAIN}/raw/docs/getting-started/installation/nodejs.md>
+- UMD (browser): <${DOMAIN}/raw/docs/getting-started/installation/umd.md>
 
 ## Explore
 
 - Getting started: <${DOMAIN}/raw/docs/getting-started.md>
-- Components: <${DOMAIN}/raw/docs/components.md>
-- Composables: <${DOMAIN}/raw/docs/composables/define-shortcuts.md>
-- Typography: <${DOMAIN}/raw/docs/typography.md>
+- Working with the REST API: <${DOMAIN}/raw/docs/working-with-the-rest-api.md>
+- B24Frame (embedded apps): <${DOMAIN}/raw/docs/working-with-the-rest-api/frame.md>
+- B24Hook (webhooks): <${DOMAIN}/raw/docs/working-with-the-rest-api/hook.md>
+- B24OAuth (server apps): <${DOMAIN}/raw/docs/working-with-the-rest-api/oauth.md>
 - Sitemap: <${DOMAIN}/sitemap.md>
 - LLMs index: <${DOMAIN}/llms.txt>
 - Full LLMs documentation: <${DOMAIN}/llms-full.txt>
@@ -59,8 +58,9 @@ Bitrix24 UI is a free and open source Vue UI library powered by [Reka UI](https:
 ## Links
 
 - Website: <${DOMAIN}>
-- GitHub: <https://github.com/bitrix24/b24ui>
-- Community: <https://t.me/b24_dev>
+- GitHub: <https://github.com/bitrix24/b24jssdk>
+- Community (EN): <https://t.me/b24_dev>
+- Community (RU): <https://t.me/bitrix24apps>
 `
 
   setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')

--- a/docs/server/routes/sitemap.xml.get.ts
+++ b/docs/server/routes/sitemap.xml.get.ts
@@ -1,7 +1,5 @@
 import { queryCollection } from '@nuxt/content/server'
 
-// const DOMAIN = 'https://bitrix24.github.io/b24ui'
-
 function xmlEscape(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;')
 }


### PR DESCRIPTION
## Что

Порт upstream-PR **bitrix24/b24jssdk#137** в RU-зеркало — зеркальная половина issue **bitrix24/b24jssdk#133** (upstream сам пометил RU-mirror как out of scope, «separate surface»).

Хендлеры под `docs/server/routes/` были скопированы из соседнего проекта **b24ui** и ни разу не адаптированы под **b24jssdk**. Самое заметное: `/raw/index.md` (LLM-facing markdown-лендинг) описывал **чужой продукт** — «Bitrix24 UI… a Vue UI component library… 125+ Tailwind components», ссылался на несуществующие тут `components.md` / `composables` / `typography` и вёл `GitHub:` на `github.com/bitrix24/b24ui`.

## Изменения (scope = `docs/server/routes/`)

- **`raw/index.md.get.ts`** — переписан лендинг под `@bitrix24/b24jssdk`: корректные title/description (из `index.yml` + nuxt-llms), фичи SDK (B24Frame / B24Hook / B24OAuth, REST v2/v3, batch, helpers, logging, TS), реальные installation-страницы (`vue`/`nuxt`/`react`/`nodejs`/`umd`) и разделы (`getting-started`, `working-with-the-rest-api` + frame/hook/oauth), `GitHub:` → `bitrix24/b24jssdk`, EN/RU community-ссылки. Убран устаревший `// …/b24ui` DOMAIN-комментарий и блок MCP/@todo (MCP уже удалён из RU-зеркала в #26/#128).
- **`raw/[...slug].md.get.ts`** — два дублирующихся not-found-ответа свёрнуты в единый `notFound()`-хелпер; убран устаревший `b24ui`-комментарий.
- **`sitemap.xml.get.ts`** — убран устаревший `b24ui`-комментарий.
- **`sitemap.md.get.ts`** — проверен, уже корректен под b24jssdk, без изменений.

Порт **дословный (EN)**, как в #137 — нулевой дрейф от upstream и согласовано с уже-англоязычными серверными роутами (метки в `sitemap.md`). RU-локализация серверного слоя — отдельной задачей (трек #29).

## Проверка

- ✅ Под `docs/server/routes/` не осталось ни одного упоминания `b24ui`.
- ⏳ Авторитетная проверка — `lint` / `typecheck` / `build` (nuxt generate) на CI этого PR: серверные роуты компилируются в контексте Nuxt/Nitro (локальный чекаут не provisioned под nuxt typecheck — как и отмечено в #137).

## Вне scope (отдельный follow-up, как и в #137)

- Остаточный `b24ui`-cruft в `docs/server/utils/transformMDC.ts` (карта ссылок `B24_DOCS.ui`, мёртвый `components-list` / запрос `/docs/components/%`). `utils/` вне scope #133 (`routes/`).
- Issue #27 (двойной baseUrl) — при разборе **не подтвердился**: реальный env `CANONICAL_URL=https://bitrix24.github.io` + `BASE_URL=/b24jssdk` даёт корректный `…/b24jssdk` без удвоения. Прокомментировано в #27.

Closes #28.

https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS)_