### PR TITLE
fix(docs): выключить Banner + chrome-ссылка GitHub → bitrix-tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-<sub>Last reviewed: 2026-06-05 (PR #26 — вырезка AI-чат/MCP)</sub>
+<sub>Last reviewed: 2026-06-09 (banner закомментирован; chrome-ссылки сайта → bitrix-tools. Ранее: PR #26 — вырезка AI-чат/MCP)</sub>
 
 Правила и конвенции для AI-агентов (Claude Code, Cursor, Codex и др.) при работе в этом репозитории.
 
@@ -47,6 +47,8 @@
 - `docs/i18n/` — translation-kit, **не сносить и не синхронизировать с upstream** (его там нет).
 - `scripts/add-anchors.mjs`, `scripts/swap-apidocs.mjs` — i18n утилиты, **не сносить**.
 - **AI-чат-ассистент и MCP-сервер — намеренно удалены** на зеркале (`docs/modules/bx-assistant/`, `docs/server/mcp/`, `docs/server/api/ai.post.ts`, чат-компоненты, зависимости `@ai-sdk/*` / `ai` / `@nuxtjs/mcp-toolkit`, блок `mcp:{}`). При sync **НЕ восстанавливать**. Генерация **llms.txt** (`nuxt-llms`, `server/plugins/llms.ts`, блок `llms:{}`) и ссылки **«Open in ChatGPT/Claude»** — ОСТАВЛЕНЫ. Полный список файлов — [`.github/AGENTS-SYNC-RUNBOOK.md` §5.1](.github/AGENTS-SYNC-RUNBOOK.md).
+- **Баннер `<Banner />`** — на зеркале **закомментирован** (`<!-- <Banner /> -->`) в `docs/app/app.vue` и `docs/app/error.vue`. При sync держать закомментированным в **обоих** файлах (upstream поставляет его активным).
+- **Chrome-ссылки самого сайта указывают на зеркало `bitrix-tools`, а не на upstream `bitrix24`**: пункт навигации «GitHub» в `docs/app/composables/useHeader.ts` → `https://github.com/bitrix-tools/b24jssdk`; `config.public.gitUrl` (footer-репозиторий, `/releases`, «edit this page») по умолчанию `bitrix-tools`. При sync **не возвращать на `bitrix24`**. NB: это НЕ противоречит правилу «`github.com/bitrix24/...` не переписывать» — то правило про **контентные ссылки на исходники SDK**, а здесь UI-chrome самого сайта.
 
 ## Кастомные якоря заголовков (`{#anchor}`)
 

--- a/docs/app/app.vue
+++ b/docs/app/app.vue
@@ -68,7 +68,7 @@ provide('files', files)
         ]"
       >
         <template v-if="!route.path.startsWith('/examples')">
-          <Banner />
+          <!-- <Banner /> -->
 
           <Header />
         </template>

--- a/docs/app/composables/useHeader.ts
+++ b/docs/app/composables/useHeader.ts
@@ -102,7 +102,7 @@ const _useHeader = () => {
     },
     {
       label: 'GitHub',
-      to: 'https://github.com/bitrix24/b24jssdk',
+      to: 'https://github.com/bitrix-tools/b24jssdk',
       icon: GitHubIcon,
       target: '_blank',
       b24ui: {


### PR DESCRIPTION
## Что
1. **`docs/app/app.vue`** — `<Banner />` закомментирован (`<!-- <Banner /> -->`). На зеркале баннер выключен (в `error.vue` он уже был закомментирован).
2. **`docs/app/composables/useHeader.ts`** — пункт навигации «GitHub» (мобильное меню): `github.com/bitrix24/b24jssdk` → **`github.com/bitrix-tools/b24jssdk`**. Это chrome самого сайта — должен вести на репозиторий зеркала.
3. **`AGENTS.md`** — зафиксированы оба правила в разделе «При sync — НЕ восстанавливать» (баннер держать закомментированным в обоих файлах; chrome-ссылки сайта → `bitrix-tools`), + bump `Last reviewed`.

## Заметка по footer-релизам
Ссылка «Релизы» в подвале **уже** ведёт на `bitrix-tools` — она строится из `config.public.gitUrl`, а его дефолт в `nuxt.config.ts` = `https://github.com/bitrix-tools/b24jssdk` (env-оверрайда нет; подтверждено на проде). Менять не требуется. Две `bitrix24`-ссылки на главной — это schema.org `sameAs` (структурные данные, не chrome).

## Проверка
Все 3 файла побайтово сверены по blob-SHA. CI (lint/typecheck/build) — авторитетная проверка. Breaking changes нет (UI/docs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS)_