### PR TITLE
ci: харднинг deploy-гейта + чистка мёртвой конфигурации

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,10 +49,6 @@ updates:
           - "@vue/*"
           - "vue-*"
           - "@vueuse/*"
-      ai-sdk:
-        patterns:
-          - "@ai-sdk/*"
-          - "ai"
       content-tooling:
         patterns:
           - "remark-*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Gate the deploy on the same checks as CI: a push to main that breaks
+      # lint/typecheck must NOT reach production (deploy.yml runs independently
+      # of ci.yml, so we re-run them here before building the artifact).
+      - name: Lint
+        run: pnpm run lint
+
       - name: Prepare Nuxt
         run: pnpm run docs:prepare
+
+      - name: Typecheck
+        run: pnpm run typecheck
 
       - name: Build static site
         run: pnpm run docs:generate

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -336,10 +336,7 @@ export default defineNuxtConfig({
   },
 
   ogImage: {
-    zeroRuntime: true,
-    security: {
-      renderTimeout: 60000
-    }
+    zeroRuntime: true
   },
 
   schemaOrg: {


### PR DESCRIPTION
CI/конфиг-находки из мульти-ревью. Три независимые правки.

## 1. `deploy.yml` — гейт деплоя на lint+typecheck **[crit]**
`deploy.yml` (триггер `push: main`) собирал артефакт и публиковал, выполняя только `docs:generate`. Он работает **независимо** от `ci.yml`, поэтому пуш в `main`, ломающий **lint** или **typecheck**, всё равно уезжал в прод (build мог пройти, а typecheck — нет).

→ В job `build` добавлены шаги `Lint` (после install) и `Typecheck` (после prepare) — теми же командами, что в `ci.yml`. Теперь сломанный `main` не публикуется.

## 2. `dependabot.yml` — удалена мёртвая группа `ai-sdk`
Группа матчила `ai` и `@ai-sdk/*`, но **их нет** в `docs/package.json` (проверено). Висячая конфигурация без эффекта.

## 3. `nuxt.config.ts` — удалён мёртвый `ogImage.security.renderTimeout`
При `zeroRuntime: true` рантайм-рендер браузером отключён, поэтому `security.renderTimeout: 60000` ни на что не влияет (+ ни одного активного `defineOgImage`). Оставлен `ogImage: { zeroRuntime: true }`.

## Проверка
- Все 3 файла **побайтово** сверены по blob-SHA (Edit на локальном снимке → git hash-object → pushed blob идентичен).
- `ci.yml` на этом PR валидирует изменение `nuxt.config.ts` (typecheck/build).
- Сам `deploy.yml`-гейт отработает на первом push в `main` после мержа (deploy не запускается на PR). Добавленные команды — те же, что в зелёном `ci.yml`.

## Не вошло
- `CHANGELOG.md` (пустой буллет в 0.1.6) — лежит в корневом changelog SDK, вероятно синкается из upstream; не трогаю во избежание дивергенции. Если нужно — отдельно.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS)_