### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.4.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.4.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.4.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -53,7 +53,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.output/public
 
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       # Smoke-test — убеждаемся, что сайт реально доступен в prod (с retry на propagation).
       - name: Smoke test deployed site


### PR DESCRIPTION
## Зачем
Деплой и CI логировали деприкейшн-ворнинги: затронутые экшены крутятся на **Node 20**. GitHub принудительно переведёт их на Node 24 с **2026-06-16**, а 2026-09-16 уберёт Node 20 из раннеров. Чиним заранее — бампом мажоров до Node-24-совместимых.

## Что
Один коммит, два воркфлоу, меняются **только версии экшенов** (пины `pnpm 11.4.0` / `node 22` сохранены):

| Экшен | Где | Было → стало |
|---|---|---|
| `actions/setup-node` | ci.yml ×3, deploy.yml | `v4 → v5` |
| `pnpm/action-setup` | ci.yml ×3, deploy.yml | `v4 → v6` |
| `actions/upload-pages-artifact` | deploy.yml | `v3 → v5` |
| `actions/deploy-pages` | deploy.yml | `v4 → v5` |

- `upload-pages-artifact v3→v5` закрывает и транзитивный `actions/upload-artifact@v4` из ворнинга (это вложенный экшен composite-обёртки).
- `deploy-pages` бампается **в паре** с `upload-pages-artifact` — формат артефакта Pages должен совпадать между ними.
- `actions/checkout@v6` и `actions/configure-pages@v6` уже на Node 24 — не трогаю.

## Поглощает dependabot-PR
Закрывает #46 (`pnpm/action-setup`), #47 (`upload-pages-artifact`), #48 (`deploy-pages`) — они правят те же строки в `deploy.yml` и иначе конфликтуют между собой. `setup-node` своего dependabot-PR не имел.

## Проверка
- `ci.yml` на этом PR валидирует `setup-node v5` + `pnpm/action-setup v6` (install/lint/typecheck/build).
- Pages-специфичные (`upload-pages-artifact v5`, `deploy-pages v5`, `configure-pages v6`) на PR не запускаются — отработают на первом push в `main` после мержа, как и сам гейт из #61.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHGoBJH3hrKVGdh6BfvVS)_